### PR TITLE
CRDCDH-474 `listApprovedStudiesOfMyOrganization`

### DIFF
--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -154,11 +154,8 @@ type Query {
     # sortDirection in ["ASC", "DESC"]
     # orderBy in ["Submitter Name", "Organization", "Study", "Program", "Status", "Submitted Date"]
 
-    # Return all approved studies
+    # Submitter and Org Owner can only list studies for their own organization, other role can see all
     listApprovedStudies: [ApprovedStudy]
-
-    # Returns only approved studies associated with the authenticated user's organization
-    listApprovedStudiesOfMyOrganization: [ApprovedStudy]
 
     "Result depends on user's permission"
     listSubmissions(

--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -154,8 +154,11 @@ type Query {
     # sortDirection in ["ASC", "DESC"]
     # orderBy in ["Submitter Name", "Organization", "Study", "Program", "Status", "Submitted Date"]
 
-    # Submitter and Org Owner can only list studies for their own organization, other role can see all
+    # Return all approved studies
     listApprovedStudies: [ApprovedStudy]
+
+    # Returns only approved studies associated with the authenticated user's organization
+    listApprovedStudiesOfMyOrganization: [ApprovedStudy]
 
     "Result depends on user's permission"
     listSubmissions(

--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -32,17 +32,17 @@ dbConnector.connect().then(() => {
     const emailParams = {url: config.emails_url, officialEmail: config.official_email, inactiveDays: config.inactive_application_days};
     const logCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, LOG_COLLECTION);
     const userService = new User(userCollection, logCollection);
-    const approvedStudiesCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, APPROVED_STUDIES_COLLECTION);
-    const approvedStudiesService = new ApprovedStudiesService(approvedStudiesCollection);
     const organizationCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, ORGANIZATION_COLLECTION);
     const organizationService = new Organization(organizationCollection);
+    const approvedStudiesCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, APPROVED_STUDIES_COLLECTION);
+    const approvedStudiesService = new ApprovedStudiesService(approvedStudiesCollection, organizationService);
     const s3Service = new S3Service();
     const batchCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, BATCH_COLLECTION);
     const batchService = new BatchService(s3Service, batchCollection, config.submission_aws_bucket_name);
     const submissionService = new Submission(logCollection, submissionCollection, batchService, userService, organizationService);
     const awsService = new AWSService(submissionCollection, userService, new Organization(organizationCollection));
     const dataInterface = new Application(logCollection, applicationCollection, approvedStudiesService, userService, dbService, notificationsService, emailParams);
-    
+
     root = {
         version: () => {return config.version},
         saveApplication: dataInterface.saveApplication.bind(dataInterface),
@@ -56,6 +56,7 @@ dbConnector.connect().then(() => {
         reopenApplication: dataInterface.reopenApplication.bind(dataInterface),
         deleteApplication: dataInterface.deleteApplication.bind(dataInterface),
         listApprovedStudies: approvedStudiesService.listApprovedStudiesAPI.bind(approvedStudiesService),
+        listApprovedStudiesOfMyOrganization: approvedStudiesService.listApprovedStudiesOfMyOrganizationAPI.bind(approvedStudiesService),
         createBatch: submissionService.createBatch.bind(submissionService),
         createSubmission: submissionService.createSubmission.bind(submissionService),
         listSubmissions:  submissionService.listSubmissions.bind(submissionService),

--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -4,8 +4,9 @@ const { verifySession } = require('../verifier/user-info-verifier');
 
 class ApprovedStudiesService {
 
-    constructor(approvedStudiesCollection) {
+    constructor(approvedStudiesCollection, organizationService) {
         this.approvedStudiesCollection = approvedStudiesCollection;
+        this.organizationService = organizationService;
     }
 
     async storeApprovedStudies(studyName, studyAbbreviation, dbGaPID, organizationName) {
@@ -21,8 +22,7 @@ class ApprovedStudiesService {
      * List Approved Studies API Interface.
      *
      * Note:
-     * - This is currently an open API for all logged-in users
-     *   filtering on Organization is not implemented in MVP-2.
+     * - This is open to any authenticated user and returns all approved studies.
      *
      * @api
      * @param {Object} params Endpoint parameters
@@ -34,6 +34,42 @@ class ApprovedStudiesService {
           .verifyInitialized();
 
         return this.listApprovedStudies({});
+    }
+
+    /**
+     * List Approved Studies of My Org API Interface.
+     *
+     * Note:
+     * - This is open to any authenticated user, but returns only approved studies tied
+     *   to the user's organization.
+     * - If no organization is associated with the user, an empty array is returned.
+     * - If no studies are associated with the user's organization, an empty array is returned.
+     *
+     * @api
+     * @param {Object} params Endpoint parameters
+     * @param {{ cookie: Object, userInfo: Object }} context request context
+     * @returns {Promise<Object[]>} An array of ApprovedStudies
+     */
+    async listApprovedStudiesOfMyOrganizationAPI(params, context) {
+        verifySession(context)
+          .verifyInitialized();
+
+        if (!context.userInfo?.organization?.orgID) {
+            return [];
+        }
+
+        const organization = await this.organizationService.getOrganizationByID(context.userInfo.organization.orgID);
+        if (!organization || !organization?.studies?.length) {
+            return [];
+        }
+
+        const filters = {
+            // NOTE: `studyAbbreviation` is a unique constraint
+            studyAbbreviation: {
+                $in: organization.studies?.filter((s) => !!s.studyAbbreviation).map((s) => s.studyAbbreviation)
+            }
+        };
+        return this.listApprovedStudies(filters);
     }
 
     /**

--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -1,4 +1,5 @@
 const {getCurrentTime} = require("../crdc-datahub-database-drivers/utility/time-utility");
+const {USER} = require("../crdc-datahub-database-drivers/constants/user-constants");
 const ERROR = require("../constants/error-constants");
 const { verifySession } = require('../verifier/user-info-verifier');
 
@@ -22,7 +23,7 @@ class ApprovedStudiesService {
      * List Approved Studies API Interface.
      *
      * Note:
-     * - This is open to any authenticated user and returns all approved studies.
+     * - This is an ADMIN only operation.
      *
      * @api
      * @param {Object} params Endpoint parameters
@@ -31,7 +32,8 @@ class ApprovedStudiesService {
      */
     async listApprovedStudiesAPI(params, context) {
         verifySession(context)
-          .verifyInitialized();
+          .verifyInitialized()
+          .verifyRole([USER.ROLES.ADMIN]);
 
         return this.listApprovedStudies({});
     }


### PR DESCRIPTION
### Overview

This PR introduces backend support for the Approved Studies dropdown on the frontend. It's an extension to `listApprovedStudies`, and filters the results to only studies assigned to an organization.

Notes:

- ~~The GraphQL schema was updated~~ See PR #104
- `listApprovedStudies` is converted to an admin only OP
- The Postman collection has been updated to include this new API
- There is no submodule update for this PR

### Related Tickets

https://tracker.nci.nih.gov/browse/CRDCDH-474
https://tracker.nci.nih.gov/browse/CRDCDH-159