### PR TITLE
fix user role results for listSubmissions

### DIFF
--- a/services/submission.js
+++ b/services/submission.js
@@ -47,7 +47,6 @@ function listConditions(userID, userRole, userDataCommons, userOrganization, par
     }
 
     // Add condition so submitters will only see their data submissions
-    // User's cant make submissions, so they will always have no submissions 
     // search by applicant's user id
     conditions = {...conditions, "submitterID": userID};
     return [{"$match": conditions}];
@@ -133,6 +132,9 @@ class Submission {
         verifySession(context)
             .verifyInitialized();
         validateListSubmissionsParams(params);
+        if (context.userInfo.role === ROLES.USER) {
+            return {submissions: [], total: 0};
+        }
         let pipeline = listConditions(context.userInfo._id, context.userInfo?.role, context.userInfo.dataCommons, context.userInfo?.organization, params);
         if (params.orderBy) pipeline.push({"$sort": { [params.orderBy]: getSortDirection(params.sortDirection) } });
       


### PR DESCRIPTION
Previously, I assumed the User role would never have submissions to view, so allowing them to see their own submissions was fine, (they can't create submissions, so they wont see any).
However, if they create submissions, then have their role changed by an admin back to user, they will still be able to see their  previously created submissions. 
This is just a more airtight way to adhere to requireents.