### PR TITLE
make dbgap optional for creating a data submission

### DIFF
--- a/services/submission.js
+++ b/services/submission.js
@@ -626,7 +626,7 @@ function listConditions(userID, userRole, userDataCommons, userOrganization, par
 }
 
 function validateCreateSubmissionParams (params) {
-    if (!params.name || !params.studyAbbreviation || !params.dataCommons || !params.dbGaPID) {
+    if (!params.name || !params.studyAbbreviation || !params.dataCommons) {
         throw new Error(ERROR.CREATE_SUBMISSION_INVALID_PARAMS);
     }
     if (!dataCommonsTempList.some((value) => value === params.dataCommons)) {


### PR DESCRIPTION
This pr makes dbgapID optional for creating a data submission, as required by ticket 606