### PR TITLE
CRDCDH-680 Remove ICDC from M2

### DIFF
--- a/services/submission.js
+++ b/services/submission.js
@@ -20,9 +20,8 @@ const ALL_FILTER = "All";
 const NA = "NA"
 const config = require("../config");
 
-// TODO: Data commons needs to be in a predefined list, currently only "CDS" and "ICDC" are allowed
-// eventually frontend and backend will use same source for this list.
-const dataCommonsTempList = ["CDS", "ICDC"];
+// TODO: Maintain one list of data commons between frontend and backend
+const dataCommonsTempList = ["CDS"];
 const UPLOAD_TYPES = ['file','metadata'];
 const LOG_DIR = 'logs';
 const LOG_FILE_EXT_ZIP ='.zip';


### PR DESCRIPTION
### Overview

Per changing requirements, this PR removes ICDC from M2 backend acceptable data commons list.

### Change Details (Specifics)

N/A

### Related Ticket(s)

https://tracker.nci.nih.gov/browse/CRDCDH-680

> [!IMPORTANT]  
> This is a fix for M2 only, and should not be merged with the Milestone 3 branch until we receive further information from K.C.