### PR TITLE
Crdcdh 736 001 pgu

### DIFF
--- a/services/batch-service.js
+++ b/services/batch-service.js
@@ -66,9 +66,7 @@ class BatchService {
         }
         // Count how many batch files updated from FE match the uploaded files.
         const isAllUploaded = files?.length > 0 && succeededFiles.length === files?.length;
-        // crdcdh-736 required updateBatch don't updated batch status for metadata to "uploaded" but let validator engine do.
-        //aBatch.status = isAllUploaded ? BATCH.STATUSES.UPLOADED : BATCH.STATUSES.FAILED;
-        aBatch.status = isAllUploaded ? aBatch.type=== BATCH.TYPE.METADATA ? BATCH.STATUSES.UPLOADING : BATCH.STATUSES.UPLOADED : BATCH.STATUSES.FAILED;
+        aBatch.status = isAllUploaded ? (aBatch.type=== BATCH.TYPE.METADATA ? BATCH.STATUSES.UPLOADING : BATCH.STATUSES.UPLOADED) : BATCH.STATUSES.FAILED;
         aBatch.updatedAt = getCurrentTime();
         await asyncUpdateBatch(this.awsService, this.batchCollection, aBatch, this.sqsLoaderQueue, isAllUploaded);
         return await this.findByID(aBatch._id);

--- a/services/batch-service.js
+++ b/services/batch-service.js
@@ -66,7 +66,9 @@ class BatchService {
         }
         // Count how many batch files updated from FE match the uploaded files.
         const isAllUploaded = files?.length > 0 && succeededFiles.length === files?.length;
-        aBatch.status = isAllUploaded ? BATCH.STATUSES.UPLOADED : BATCH.STATUSES.FAILED;
+        // crdcdh-736 required updateBatch don't updated batch status for metadata to "uploaded" but let validator engine do.
+        //aBatch.status = isAllUploaded ? BATCH.STATUSES.UPLOADED : BATCH.STATUSES.FAILED;
+        aBatch.status = isAllUploaded ? aBatch.type=== BATCH.TYPE.METADATA ? BATCH.STATUSES.UPLOADING : BATCH.STATUSES.UPLOADED : BATCH.STATUSES.FAILED;
         aBatch.updatedAt = getCurrentTime();
         await asyncUpdateBatch(this.awsService, this.batchCollection, aBatch, this.sqsLoaderQueue, isAllUploaded);
         return await this.findByID(aBatch._id);

--- a/services/submission.js
+++ b/services/submission.js
@@ -140,10 +140,11 @@ class Submission {
         await verifyBatchPermission(this.userService, aSubmission, userInfo);
         const res = await this.batchService.updateBatch(aBatch, params?.files, userInfo);
         // new status is ready for the validation
+        // crdcdh-736 required don't update metadataValidationStatus when update batch
         if (res.status === BATCH.STATUSES.UPLOADED) {
             const updateSubmission = {
                 _id: aSubmission._id,
-                ...(res?.type === VALIDATION.TYPES.METADATA ? {metadataValidationStatus: VALIDATION_STATUS.NEW} : {}),
+                //...(res?.type === VALIDATION.TYPES.METADATA ? {metadataValidationStatus: VALIDATION_STATUS.NEW} : {}),
                 ...(res?.type === VALIDATION.TYPES.FILE ? {fileValidationStatus: VALIDATION_STATUS.NEW} : {}),
                 updatedAt: getCurrentTime()
             }
@@ -405,9 +406,10 @@ class Submission {
             return;
         }
         const updated = await this.submissionCollection.update({_id: aSubmission?._id, ...typesToUpdate});
-        if (!updated?.modifiedCount || updated?.modifiedCount < 1) {
-            throw new Error(ERROR.FAILED_VALIDATE_METADATA);
-        }
+        //no need to throw exception here
+        // if (!updated?.modifiedCount || updated?.modifiedCount < 1) {
+        //     throw new Error(ERROR.FAILED_VALIDATE_METADATA);
+        // }
     }
 }
 

--- a/services/submission.js
+++ b/services/submission.js
@@ -140,11 +140,9 @@ class Submission {
         await verifyBatchPermission(this.userService, aSubmission, userInfo);
         const res = await this.batchService.updateBatch(aBatch, params?.files, userInfo);
         // new status is ready for the validation
-        // crdcdh-736 required don't update metadataValidationStatus when update batch
         if (res.status === BATCH.STATUSES.UPLOADED) {
             const updateSubmission = {
                 _id: aSubmission._id,
-                //...(res?.type === VALIDATION.TYPES.METADATA ? {metadataValidationStatus: VALIDATION_STATUS.NEW} : {}),
                 ...(res?.type === VALIDATION.TYPES.FILE ? {fileValidationStatus: VALIDATION_STATUS.NEW} : {}),
                 updatedAt: getCurrentTime()
             }

--- a/services/submission.js
+++ b/services/submission.js
@@ -406,10 +406,9 @@ class Submission {
             return;
         }
         const updated = await this.submissionCollection.update({_id: aSubmission?._id, ...typesToUpdate});
-        //no need to throw exception here
-        // if (!updated?.modifiedCount || updated?.modifiedCount < 1) {
-        //     throw new Error(ERROR.FAILED_VALIDATE_METADATA);
-        // }
+        if (!updated?.modifiedCount || updated?.modifiedCount < 1) {
+            throw new Error(ERROR.FAILED_VALIDATE_METADATA);
+        }
     }
 }
 


### PR DESCRIPTION
1.  Don't update metadataValidationStatus of submission to "New", let essential validator service do.
2.  Don't update batch status to "Uploaded" after tsv files are uploaded into s3 bucket.  Let essential validator to do so.