### PR TITLE
Update secondary sort direction

### DIFF
--- a/services/data-record-service.js
+++ b/services/data-record-service.js
@@ -157,12 +157,15 @@ class DataRecordService {
             });
         }
         let page_pipeline = [];
-        let direction = getSortDirection(sortDirection);
+        const nodeType = "nodeType";
+        let sortFields = {
+            [orderBy]: getSortDirection(sortDirection),
+        };
+        if (orderBy !== nodeType){
+            sortFields[nodeType] = 1
+        }
         page_pipeline.push({
-            $sort: {
-                [orderBy]: direction,
-                "nodeType": direction
-            }
+            $sort: sortFields
         });
         page_pipeline.push({
             $skip: offset


### PR DESCRIPTION
- Remove nodeType secondary sort if primary sort is nodeType
- Lock secondary sort direction to ascending regardless of primary sort direction