### PR TITLE
CRDCDH-998

### DIFF
--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -286,6 +286,7 @@ type DataRecord {
 #    rawData: RawData
     s3FileInfo: S3FileInfo # only for "file" types, should be null for other nodes
     CRDC_ID: String
+    additionalErrors: [ErrorMessage]
 }
 
 type S3FileInfo {

--- a/services/data-record-service.js
+++ b/services/data-record-service.js
@@ -146,6 +146,13 @@ class DataRecordService {
                     submittedID: "$s3FileInfo.fileName",
                     errors: "$s3FileInfo.errors",
                     warnings: "$s3FileInfo.warnings",
+                },
+                additional_errors: {
+                    validation_type: BATCH.TYPE.METADATA,
+                    type: "$nodeType",
+                    submittedID: "$nodeID",
+                    errors: "$additionalErrors",
+                    warnings: [],
                 }
             }
         })
@@ -155,6 +162,7 @@ class DataRecordService {
                 results: [
                     "$metadata_results",
                     "$datafile_results",
+                    "$additional_errors",
                 ]
             }
         })


### PR DESCRIPTION
Read cross-submission errors stored in DataRecord.additional_errors and include them in the submissionQCResults API