### PR TITLE
fix validation record issue.

### DIFF
--- a/services/submission.js
+++ b/services/submission.js
@@ -404,6 +404,10 @@ class Submission {
 
         await this.#updateValidationStatus(params?.types, aSubmission, VALIDATION_STATUS.VALIDATING, VALIDATION_STATUS.VALIDATING, VALIDATION_STATUS.VALIDATING, getCurrentTime());
         const validationRecord = ValidationRecord.createValidation(aSubmission?._id, params?.types, params?.scope, VALIDATION_STATUS.VALIDATING);
+        const res = await this.validationCollection.insert(validationRecord);
+        if (!res?.acknowledged) {
+            throw new Error(ERROR.FAILED_INSERT_VALIDATION_OBJECT);
+        }
         const result = await this.dataRecordService.validateMetadata(params._id, params?.types, params?.scope, validationRecord._id);
         const updatedSubmission = await this.#recordSubmissionValidation(params._id, validationRecord, params?.types, aSubmission);
         // roll back validation if service failed
@@ -847,10 +851,10 @@ class Submission {
         if (!updated?.value) {
             throw new Error(ERROR.FAILED_RECORD_VALIDATION_PROPERTY);
         }
-        const res = await this.validationCollection.insert(ValidationRecord.createValidation(submissionID, dataValidation.validationType, dataValidation.validationScope, VALIDATION_STATUS.VALIDATING));
-        if (!res?.acknowledged) {
-            throw new Error(ERROR.FAILED_INSERT_VALIDATION_OBJECT);
-        }
+        // const res = await this.validationCollection.insert(ValidationRecord.createValidation(submissionID, dataValidation.validationType, dataValidation.validationScope, VALIDATION_STATUS.VALIDATING));
+        // if (!res?.acknowledged) {
+        //     throw new Error(ERROR.FAILED_INSERT_VALIDATION_OBJECT);
+        // }
         return updated.value;
     }
 }

--- a/services/submission.js
+++ b/services/submission.js
@@ -851,10 +851,6 @@ class Submission {
         if (!updated?.value) {
             throw new Error(ERROR.FAILED_RECORD_VALIDATION_PROPERTY);
         }
-        // const res = await this.validationCollection.insert(ValidationRecord.createValidation(submissionID, dataValidation.validationType, dataValidation.validationScope, VALIDATION_STATUS.VALIDATING));
-        // if (!res?.acknowledged) {
-        //     throw new Error(ERROR.FAILED_INSERT_VALIDATION_OBJECT);
-        // }
         return updated.value;
     }
 }


### PR DESCRIPTION
Hi Young,  during integration testing for crdcdh-1233, found the validation record is not saved to db before send message,  after sent, a new validation record with new _id is inserted to DB.  This caused the validator can't find the validation with the id passed via sqs message,   I fixed the issue and works now.  Please review.