### PR TITLE
CRDCDH-1430 Add `ORCID` Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 **/.DS_Store
 *.vscode*
 local-files
+coverage

--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -91,6 +91,7 @@ type Submission {
     validationScope: String
     studyID: String
     controlledAccess: Boolean
+    ORCID: String
     deletingData: Boolean
 }
 
@@ -177,6 +178,7 @@ type ApprovedStudy {
     studyAbbreviation: String # must be unique
     dbGaPID: String # aka. phs number
     controlledAccess: Boolean
+    ORCID: String
 }
 
 type ListLogFiles {
@@ -395,7 +397,7 @@ type AsyncProcessResult {
 type SubmissionNodes {
     total: Int, #total nodes of a given nodeType and data submission
     IDPropName: String,
-    properties: [String], #all properties of a node including parents 
+    properties: [String], #all properties of a node including parents
     nodes: [Node]
 }
 
@@ -511,7 +513,7 @@ type Query {
     getOrganization(orgID: ID!): UserOrganization
 
     getSubmissionNodes(
-        submissionID: String!, 
+        submissionID: String!,
         nodeType: String!,
         status: String = "All", # ["All", "New", "Error", "Passed", "Warning"]
         nodeID: String,
@@ -556,7 +558,7 @@ type Mutation {
 
     "Fed lead initiated operations"
     reviewApplication (_id: ID!): Application # same as getApplication but will set Application to "In Review" state
-    approveApplication (_id: ID!, wholeProgram: Boolean, comment: String, institutions: [String]): Application
+    approveApplication (_id: ID!, wholeProgram: Boolean, comment: String, institutions: [String], ORCID: String): Application
     rejectApplication (_id: ID!, comment: String!): Application
     inquireApplication (_id: ID!, comment: String!): Application
 

--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -15,6 +15,7 @@ type Application {
     studyName: String
     studyAbbreviation: String
     controlledAccess: Boolean
+    ORCID: String
     # questionnaire data as JSON string
     questionnaireData: String
 }
@@ -33,6 +34,7 @@ input AppInput {
     questionnaireData: String
     studyName: String!
     controlledAccess: Boolean!
+    ORCID: String
 }
 
 type Applicant {
@@ -558,7 +560,7 @@ type Mutation {
 
     "Fed lead initiated operations"
     reviewApplication (_id: ID!): Application # same as getApplication but will set Application to "In Review" state
-    approveApplication (_id: ID!, wholeProgram: Boolean, comment: String, institutions: [String], ORCID: String): Application
+    approveApplication (_id: ID!, wholeProgram: Boolean, comment: String, institutions: [String]): Application
     rejectApplication (_id: ID!, comment: String!): Application
     inquireApplication (_id: ID!, comment: String!): Application
 

--- a/services/application.js
+++ b/services/application.js
@@ -259,7 +259,7 @@ class Application {
         promises.push(this.sendEmailAfterApproveApplication(context, application));
         if (updated?.modifiedCount && updated?.modifiedCount > 0) {
             promises.unshift(this.getApplicationById(document._id));
-            promises.push(saveApprovedStudies(this.approvedStudiesService, this.organizationService, application, document.ORCID));
+            promises.push(saveApprovedStudies(this.approvedStudiesService, this.organizationService, application));
             promises.push(this.logCollection.insert(
                 UpdateApplicationStateEvent.create(context.userInfo._id, context.userInfo.email, context.userInfo.IDP, application._id, application.status, APPROVED)
             ));
@@ -512,7 +512,7 @@ const sendEmails = {
     }
 }
 
-const saveApprovedStudies = async (approvedStudiesService, organizationService, aApplication, ORCID = "") => {
+const saveApprovedStudies = async (approvedStudiesService, organizationService, aApplication) => {
     const questionnaire = parseJsonString(aApplication?.questionnaireData);
     if (!questionnaire) {
         console.error(ERROR.FAILED_STORE_APPROVED_STUDIES + ` id=${aApplication?._id}`);
@@ -525,7 +525,7 @@ const saveApprovedStudies = async (approvedStudiesService, organizationService, 
         console.error(ERROR.APPLICATION_CONTROLLED_ACCESS_NOT_FOUND, ` id=${aApplication?._id}`);
     }
     const savedApprovedStudy = await approvedStudiesService.storeApprovedStudies(
-        aApplication?.studyName, studyAbbreviation, questionnaire?.study?.dbGaPPPHSNumber, aApplication?.organization?.name, controlledAccess, ORCID
+        aApplication?.studyName, studyAbbreviation, questionnaire?.study?.dbGaPPPHSNumber, aApplication?.organization?.name, controlledAccess, aApplication?.ORCID
     );
 
     const orgApprovedStudies = [savedApprovedStudy]?.map((study) => ({

--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -10,8 +10,8 @@ class ApprovedStudiesService {
         this.organizationService = organizationService;
     }
 
-    async storeApprovedStudies(studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess) {
-        const approvedStudies = ApprovedStudies.createApprovedStudies(studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess);
+    async storeApprovedStudies(studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess, ORCID) {
+        const approvedStudies = ApprovedStudies.createApprovedStudies(studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess, ORCID);
         const res = await this.approvedStudiesCollection.findOneAndUpdate({ studyName }, approvedStudies, {returnDocument: 'after', upsert: true});
         if (!res?.value) {
             console.error(ERROR.APPROVED_STUDIES_INSERTION + ` studyName: ${studyName}`);
@@ -22,7 +22,7 @@ class ApprovedStudiesService {
     /**
      * List Approved Studies by a studyName API.
      * @api
-     * @param {string} - studyName
+     * @param {string} studyName
      * @returns {Promise<Object[]>} An array of ApprovedStudies
      */
     async findByStudyName(studyName) {

--- a/services/submission.js
+++ b/services/submission.js
@@ -1445,6 +1445,7 @@ class DataSubmission {
         if (!isUndefined(approvedStudy?.controlledAccess)) {
             this.controlledAccess = approvedStudy.controlledAccess;
         }
+        this.ORCID = approvedStudy?.ORCID || null;
         this.accessedAt = getCurrentTime();
     }
 


### PR DESCRIPTION
### Overview

This PR updates the Submission Request functionality to support an additional (optional) `ORCID` field provided by the frontend. When provided, this field is stored within the ApprovedStudy collection during application approval. This PR also extends the Data Submission creation functionality to populate a new property `ORCID` when the selected study has this field defined.

> [!Warning]
> This feature is for the 3.1.0 release, not 3.0.0

> [!Warning]
> This PR also depends on a drivers update in PR https://github.com/CBIIT/crdc-datahub-database-drivers/pull/103

### Change Details (Specifics)

- Add `ORCID` to the `Submission`, `ApprovedStudy`, and `Application` types
- Update AppInput to support `ORCID` string input
- Update the approveApplication handling to pass `ORCID` to the ApprovedStudy if it's defined
- Update the createSubmission handling to populate `ORCID` if defined

### Related Ticket(s)

CRDCDH-1430 (BE Task)
