### PR TITLE
CRDCDH-1489 Added additional submission statuses to otherSubmissions property

### DIFF
--- a/services/submission.js
+++ b/services/submission.js
@@ -211,9 +211,15 @@ class Submission {
                 const submissions = await this.submissionCollection.aggregate([
                     {"$match": {$and: [
                         {studyID: aSubmission.studyID},
-                        {status: {$in: [IN_PROGRESS, SUBMITTED, RELEASED]}},
+                        {status: {$in: [IN_PROGRESS, SUBMITTED, RELEASED, REJECTED, WITHDRAWN]}},
                         {_id: { $not: { $eq: params._id}}}]}}]);
-                const otherSubmissions = {[IN_PROGRESS]: [], [SUBMITTED]: [], [RELEASED]: []};
+                const otherSubmissions = {
+                    [IN_PROGRESS]: [],
+                    [SUBMITTED]: [],
+                    [RELEASED]: [],
+                    [REJECTED]: [],
+                    [WITHDRAWN]: [],
+                };
                 submissions.forEach((submission) => {
                     otherSubmissions[submission.status].push(submission._id);
                 });


### PR DESCRIPTION
### Overview

Added submission status "Rejected" and "Withdrawn" to be included in the `otherSubmissions` property with the `getSubmission` API response.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-1489](https://tracker.nci.nih.gov/browse/CRDCDH-1489)
