### PR TITLE
CRDCDH-1545 Validate dbGaPID for controlled studies when creating a submission

### DIFF
--- a/services/submission.js
+++ b/services/submission.js
@@ -79,6 +79,9 @@ class Submission {
         if (!approvedStudy) {
             throw new Error(ERROR.CREATE_SUBMISSION_NO_MATCHING_STUDY);
         }
+        if (approvedStudy.controlledAccess && !params.dbGaPID?.trim()?.length) {
+            throw new Error(ERROR.CREATE_SUBMISSION_INVALID_PARAMS);
+        }
         const modelVersion = this.#getModelVersion(this.dataModelInfo, params.dataCommons);
         const newSubmission = DataSubmission.createSubmission(
             params.name, context.userInfo, params.dataCommons, params.studyID, params.dbGaPID, aUserOrganization, modelVersion, intention, dataType, approvedStudy);


### PR DESCRIPTION
### Overview

Added an additional guard to ensure that a valid dbGaPID param is passed to createSubmission API when the study chosen has controlled access.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-1545](https://tracker.nci.nih.gov/browse/CRDCDH-1545)