### PR TITLE
CRDCDH-1545 Improved error message for missing dbGaPID when study with controlled access is selected

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -60,6 +60,7 @@ const ERROR = {
     UPDATE_SUBMISSION_ERROR:"An error occurred while attempting to update the submission in the database",
     CREATE_SUBMISSION_INVALID_DATA_COMMONS: "Invalid Data Commons for creating a submission",
     CREATE_SUBMISSION_NO_MATCHING_STUDY: "The study provided does not match an approved study within the user's organization",
+    MISSING_CREATE_SUBMISSION_DBGAPID: "Submission dbGaPID is required for creating a data submission with a controlled access study.",
     // List Submissions
     LIST_SUBMISSION_INVALID_STATUS_FILTER: "The status filter is invalid",
     INVALID_SUBMISSION_PERMISSION: "You do not have the correct permissions to list submissions",

--- a/services/submission.js
+++ b/services/submission.js
@@ -80,7 +80,7 @@ class Submission {
             throw new Error(ERROR.CREATE_SUBMISSION_NO_MATCHING_STUDY);
         }
         if (approvedStudy.controlledAccess && !params.dbGaPID?.trim()?.length) {
-            throw new Error(ERROR.CREATE_SUBMISSION_INVALID_PARAMS);
+            throw new Error(ERROR.MISSING_CREATE_SUBMISSION_DBGAPID);
         }
         const modelVersion = this.#getModelVersion(this.dataModelInfo, params.dataCommons);
         const newSubmission = DataSubmission.createSubmission(


### PR DESCRIPTION
### Overview

This PR is just for updating an error message while creating a data submission. This error occurs when the user is missing a dbGaPID and chooses a study with controlled access.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-1545](https://tracker.nci.nih.gov/browse/CRDCDH-1545)