### PR TITLE
CRDCDH-1544 Check Submission name length without trimming whitespace

### DIFF
--- a/services/submission.js
+++ b/services/submission.js
@@ -1343,7 +1343,7 @@ function validateCreateSubmissionParams (params, allowedDataCommons, intention, 
     if (!params.name || params?.name?.trim().length === 0 || !params.studyID || !params.dataCommons) {
         throw new Error(ERROR.CREATE_SUBMISSION_INVALID_PARAMS);
     }
-    if (params?.name?.trim().length > CONSTRAINTS.NAME_MAX_LENGTH) {
+    if (params?.name?.length > CONSTRAINTS.NAME_MAX_LENGTH) {
         throw new Error(replaceErrorString(ERROR.CREATE_SUBMISSION_INVALID_NAME, `${CONSTRAINTS.NAME_MAX_LENGTH}`));
     }
     if (!allowedDataCommons.has(params.dataCommons)) {


### PR DESCRIPTION
### Overview

Check the submission name character length without trimming the whitespace. This implementation also matches the FE as it also restricts the input to 25 characters without trimming the whitespace.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-1544](https://tracker.nci.nih.gov/browse/CRDCDH-1544)