### PR TITLE
CRDCDH-1748 Create API to fetch a Approved Study by ID

### DIFF
--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -503,6 +503,8 @@ type Query {
         orderBy: String = "studyName", #property name to be used for sorting 
         sortDirection: String = "ASC" #["DESC", "ASC"]
     ): ApprovedStudyList
+    
+    getApprovedStudy(_id: ID!): ApprovedStudy
 
     "Result depends on user's permission"
     listSubmissions(

--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -103,6 +103,7 @@ dbConnector.connect().then(async () => {
         listApprovedStudies: approvedStudiesService.listApprovedStudiesAPI.bind(approvedStudiesService),
         createApprovedStudy: approvedStudiesService.addApprovedStudyAPI.bind(approvedStudiesService),
         updateApprovedStudy: approvedStudiesService.editApprovedStudyAPI.bind(approvedStudiesService),
+        getApprovedStudy: approvedStudiesService.getApprovedStudyAPI.bind(approvedStudiesService),
         listApprovedStudiesOfMyOrganization: approvedStudiesService.listApprovedStudiesOfMyOrganizationAPI.bind(approvedStudiesService),
         createBatch: submissionService.createBatch.bind(submissionService),
         updateBatch: submissionService.updateBatch.bind(submissionService),

--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -35,6 +35,48 @@ class ApprovedStudiesService {
     }
 
     /**
+     * Get an Approved Study by ID API Interface.
+     * 
+     * @api
+     * @note This is an ADMIN only operation.
+     * @param {{ _id: string }} params Endpoint parameters
+     * @param {{ cookie: Object, userInfo: Object }} context the request context
+     * @returns {Promise<Object>} The requested ApprovedStudy
+     * @throws {Error} If the study is not found
+     */
+    async getApprovedStudyAPI(params, context) {
+        verifySession(context)
+          .verifyInitialized()
+          .verifyRole([USER.ROLES.ADMIN]);
+
+        return this.getApprovedStudy(params);
+    }
+
+
+    /**
+     * Fetch an approved study by ID.
+     * 
+     * @note This does not perform any RBAC checks. 
+     * @see {@link getApprovedStudyAPI} for the API interface.
+     * @param {{ _id: string }} params The endpoint parameters
+     * @returns {Promise<Object>} The requested ApprovedStudy
+     * @throws {Error} If the study is not found or the ID is invalid
+     */
+    async getApprovedStudy({ _id }) {
+        if (!_id || typeof _id !== "string") {
+            throw new Error(ERROR.APPROVED_STUDY_NOT_FOUND);
+        }
+
+        const study = await this.approvedStudiesCollection.find(_id);
+        if (!study || !study.length) {
+            throw new Error(ERROR.APPROVED_STUDY_NOT_FOUND);
+        }
+
+        return study[0];
+    }
+
+
+    /**
      * List Approved Studies API Interface.
      *
      * Note:


### PR DESCRIPTION
### Overview

This is a quick PR to add an API endpoint to fetch a approved study by ID. This is a blocker for [CRDCDH-1485](https://tracker.nci.nih.gov/browse/CRDCDH-1485).

### Change Details (Specifics)

- Add Admin-only `getApprovedStudy` API functionality
- Update GraphQL schema accordingly

### Related Ticket(s)

[CRDCDH-1748](https://tracker.nci.nih.gov/browse/CRDCDH-1748)
