### PR TITLE
HOTFIX: Organization Name lookup not returning populated studies

### DIFF
--- a/services/submission.js
+++ b/services/submission.js
@@ -81,7 +81,7 @@ class Submission {
         const dataType = [DATA_TYPE.METADATA_AND_DATA_FILES, DATA_TYPE.METADATA_ONLY].find((i) => i.toLowerCase() === params?.dataType.toLowerCase());
         validateCreateSubmissionParams(params, this.allowedDataCommons, this.hiddenDataCommons, intention, dataType, context?.userInfo);
 
-        const aUserOrganization= await this.organizationService.getOrganizationByName(context.userInfo?.organization?.orgName);
+        const aUserOrganization = await this.organizationService.getOrganizationByID(context.userInfo?.organization?.orgID, false);
         const approvedStudy = aUserOrganization.studies.find((study) => study?._id === params.studyID);
         if (!approvedStudy) {
             throw new Error(ERROR.CREATE_SUBMISSION_NO_MATCHING_STUDY);


### PR DESCRIPTION
### Overview

Minor PR to restore the Data Submission creation functionality. The `getOrganizationByName` call does not populate the studies field by default, but we also have the Organization ID in this context, so I swapped it out with `getOrganizationByID`. See PR #534 for context.

<img width="848" alt="Screenshot 2024-11-05 at 2 58 25 PM" src="https://github.com/user-attachments/assets/46fc7181-3034-464f-9ed2-891cb95c3f20">

### Change Details (Specifics)

- Replace `createSubmission`'s call to `getOrganizationByName` with `getOrganizationByID`

### Related Ticket(s)

CRDCDH-1853 (Bug)