### PR TITLE
feat: Add `order` to PBAC Notification and Permissions

### DIFF
--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -518,6 +518,7 @@ type Permission {
     _id: String!,  #Permission Internal Name, unique 
     group: String!, #permission group
     name: String!, #permission name
+    order: Int,
     checked: Boolean,
     disabled: Boolean
 }
@@ -526,6 +527,7 @@ type Notification {
     _id: String!,  #Notification Internal Name, unique 
     group: String!, #Notification group
     name: String!, #Notification name
+    order: Int,
     checked: Boolean, 
     disabled: Boolean
 }

--- a/resources/json/PBACDefaults_config.json
+++ b/resources/json/PBACDefaults_config.json
@@ -58,6 +58,7 @@
             "_id": "data_submission:view",
             "group": "Data Submission Permissions",
             "name": "View",
+            "order": 1,
             "checked": true,
             "disabled": false
           },
@@ -65,6 +66,7 @@
             "_id": "data_submission:create",
             "group": "Data Submission Permissions",
             "name": "Create",
+            "order": 2,
             "checked": false,
             "disabled": false
           },
@@ -72,6 +74,7 @@
             "_id": "data_submission:review",
             "group": "Data Submission Permissions",
             "name": "Review",
+            "order": 3,
             "checked": false,
             "disabled": false
           },
@@ -79,6 +82,7 @@
             "_id": "data_submission:admin_submit",
             "group": "Data Submission Permissions",
             "name": "Admin Submit",
+            "order": 4,
             "checked": false,
             "disabled": true
           },
@@ -86,6 +90,7 @@
             "_id": "data_submission:confirm",
             "group": "Data Submission Permissions",
             "name": "Confirm",
+            "order": 5,
             "checked": false,
             "disabled": false
           },
@@ -288,6 +293,7 @@
             "_id": "data_submission:view",
             "group": "Data Submission Permissions",
             "name": "View",
+            "order": 1,
             "checked": true,
             "disabled": false
           },
@@ -295,6 +301,7 @@
             "_id": "data_submission:create",
             "group": "Data Submission Permissions",
             "name": "Create",
+            "order": 2,
             "checked": false,
             "disabled": false
           },
@@ -302,6 +309,7 @@
             "_id": "data_submission:review",
             "group": "Data Submission Permissions",
             "name": "Review",
+            "order": 3,
             "checked": true,
             "disabled": false
           },
@@ -309,6 +317,7 @@
             "_id": "data_submission:admin_submit",
             "group": "Data Submission Permissions",
             "name": "Admin Submit",
+            "order": 4,
             "checked": true,
             "disabled": false
           },
@@ -316,6 +325,7 @@
             "_id": "data_submission:confirm",
             "group": "Data Submission Permissions",
             "name": "Confirm",
+            "order": 5,
             "checked": true,
             "disabled": false
           },
@@ -518,6 +528,7 @@
             "_id": "data_submission:view",
             "group": "Data Submission Permissions",
             "name": "View",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -525,6 +536,7 @@
             "_id": "data_submission:create",
             "group": "Data Submission Permissions",
             "name": "Create",
+            "order": 2,
             "checked": false,
             "disabled": true
           },
@@ -532,6 +544,7 @@
             "_id": "data_submission:review",
             "group": "Data Submission Permissions",
             "name": "Review",
+            "order": 3,
             "checked": true,
             "disabled": true
           },
@@ -539,6 +552,7 @@
             "_id": "data_submission:admin_submit",
             "group": "Data Submission Permissions",
             "name": "Admin Submit",
+            "order": 4,
             "checked": true,
             "disabled": true
           },
@@ -546,6 +560,7 @@
             "_id": "data_submission:confirm",
             "group": "Data Submission Permissions",
             "name": "Confirm",
+            "order": 5,
             "checked": true,
             "disabled": true
           },
@@ -748,6 +763,7 @@
             "_id": "data_submission:view",
             "group": "Data Submission Permissions",
             "name": "View",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -755,6 +771,7 @@
             "_id": "data_submission:create",
             "group": "Data Submission Permissions",
             "name": "Create",
+            "order": 2,
             "checked": true,
             "disabled": true
           },
@@ -762,6 +779,7 @@
             "_id": "data_submission:review",
             "group": "Data Submission Permissions",
             "name": "Review",
+            "order": 3,
             "checked": false,
             "disabled": true
           },
@@ -769,6 +787,7 @@
             "_id": "data_submission:admin_submit",
             "group": "Data Submission Permissions",
             "name": "Admin Submit",
+            "order": 4,
             "checked": false,
             "disabled": true
           },
@@ -776,6 +795,7 @@
             "_id": "data_submission:confirm",
             "group": "Data Submission Permissions",
             "name": "Confirm",
+            "order": 5,
             "checked": false,
             "disabled": true
           },
@@ -978,6 +998,7 @@
             "_id": "data_submission:view",
             "group": "Data Submission Permissions",
             "name": "View",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
@@ -985,6 +1006,7 @@
             "_id": "data_submission:create",
             "group": "Data Submission Permissions",
             "name": "Create",
+            "order": 2,
             "checked": false,
             "disabled": true
           },
@@ -992,6 +1014,7 @@
             "_id": "data_submission:review",
             "group": "Data Submission Permissions",
             "name": "Review",
+            "order": 3,
             "checked": false,
             "disabled": true
           },
@@ -999,6 +1022,7 @@
             "_id": "data_submission:admin_submit",
             "group": "Data Submission Permissions",
             "name": "Admin Submit",
+            "order": 4,
             "checked": false,
             "disabled": true
           },
@@ -1006,6 +1030,7 @@
             "_id": "data_submission:confirm",
             "group": "Data Submission Permissions",
             "name": "Confirm",
+            "order": 5,
             "checked": false,
             "disabled": true
           },

--- a/resources/json/PBACDefaults_config.json
+++ b/resources/json/PBACDefaults_config.json
@@ -132,6 +132,7 @@
             "_id": "submission_request:submitted",
             "group": "Submission Request Emails",
             "name": "When Submitted",
+            "order": 1,
             "checked": false,
             "disabled": false
           },
@@ -139,6 +140,7 @@
             "_id": "submission_request:to_be_reviewed",
             "group": "Submission Request Emails",
             "name": "When available for review",
+            "order": 2,
             "checked": true,
             "disabled": false
           },
@@ -146,6 +148,7 @@
             "_id": "submission_request:reviewed",
             "group": "Submission Request Emails",
             "name": "When review decision made",
+            "order": 3,
             "checked": true,
             "disabled": false
           },
@@ -153,6 +156,7 @@
             "_id": "submission_request:deleted",
             "group": "Submission Request Emails",
             "name": "When deleted",
+            "order": 5,
             "checked": true,
             "disabled": false
           },
@@ -160,6 +164,7 @@
             "_id": "submission_request:expiring",
             "group": "Submission Request Emails",
             "name": "When expiring",
+            "order": 4,
             "checked": true,
             "disabled": false
           },
@@ -371,6 +376,7 @@
             "_id": "submission_request:submitted",
             "group": "Submission Request Emails",
             "name": "When Submitted",
+            "order": 1,
             "checked": false,
             "disabled": false
           },
@@ -378,6 +384,7 @@
             "_id": "submission_request:to_be_reviewed",
             "group": "Submission Request Emails",
             "name": "When available for review",
+            "order": 2,
             "checked": false,
             "disabled": false
           },
@@ -385,6 +392,7 @@
             "_id": "submission_request:reviewed",
             "group": "Submission Request Emails",
             "name": "When review decision made",
+            "order": 3,
             "checked": false,
             "disabled": false
           },
@@ -392,6 +400,7 @@
             "_id": "submission_request:deleted",
             "group": "Submission Request Emails",
             "name": "When deleted",
+            "order": 5,
             "checked": false,
             "disabled": false
           },
@@ -399,6 +408,7 @@
             "_id": "submission_request:expiring",
             "group": "Submission Request Emails",
             "name": "When expiring",
+            "order": 4,
             "checked": false,
             "disabled": false
           },
@@ -610,6 +620,7 @@
             "_id": "submission_request:submitted",
             "group": "Submission Request Emails",
             "name": "When Submitted",
+            "order": 1,
             "checked": false,
             "disabled": false
           },
@@ -617,6 +628,7 @@
             "_id": "submission_request:to_be_reviewed",
             "group": "Submission Request Emails",
             "name": "When available for review",
+            "order": 2,
             "checked": true,
             "disabled": false
           },
@@ -624,6 +636,7 @@
             "_id": "submission_request:reviewed",
             "group": "Submission Request Emails",
             "name": "When review decision made",
+            "order": 3,
             "checked": true,
             "disabled": false
           },
@@ -631,6 +644,7 @@
             "_id": "submission_request:deleted",
             "group": "Submission Request Emails",
             "name": "When deleted",
+            "order": 5,
             "checked": true,
             "disabled": false
           },
@@ -638,6 +652,7 @@
             "_id": "submission_request:expiring",
             "group": "Submission Request Emails",
             "name": "When expiring",
+            "order": 4,
             "checked": false,
             "disabled": false
           },
@@ -849,6 +864,7 @@
             "_id": "submission_request:submitted",
             "group": "Submission Request Emails",
             "name": "When Submitted",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -856,6 +872,7 @@
             "_id": "submission_request:to_be_reviewed",
             "group": "Submission Request Emails",
             "name": "When available for review",
+            "order": 2,
             "checked": false,
             "disabled": true
           },
@@ -863,6 +880,7 @@
             "_id": "submission_request:reviewed",
             "group": "Submission Request Emails",
             "name": "When review decision made",
+            "order": 3,
             "checked": true,
             "disabled": true
           },
@@ -870,6 +888,7 @@
             "_id": "submission_request:deleted",
             "group": "Submission Request Emails",
             "name": "When deleted",
+            "order": 5,
             "checked": true,
             "disabled": true
           },
@@ -877,6 +896,7 @@
             "_id": "submission_request:expiring",
             "group": "Submission Request Emails",
             "name": "When expiring",
+            "order": 4,
             "checked": true,
             "disabled": true
           },
@@ -1088,6 +1108,7 @@
             "_id": "submission_request:submitted",
             "group": "Submission Request Emails",
             "name": "When Submitted",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -1095,6 +1116,7 @@
             "_id": "submission_request:to_be_reviewed",
             "group": "Submission Request Emails",
             "name": "When available for review",
+            "order": 2,
             "checked": false,
             "disabled": true
           },
@@ -1102,6 +1124,7 @@
             "_id": "submission_request:reviewed",
             "group": "Submission Request Emails",
             "name": "When review decision made",
+            "order": 3,
             "checked": true,
             "disabled": true
           },
@@ -1109,6 +1132,7 @@
             "_id": "submission_request:deleted",
             "group": "Submission Request Emails",
             "name": "When deleted",
+            "order": 5,
             "checked": true,
             "disabled": true
           },
@@ -1116,6 +1140,7 @@
             "_id": "submission_request:expiring",
             "group": "Submission Request Emails",
             "name": "When expiring",
+            "order": 4,
             "checked": true,
             "disabled": true
           },

--- a/resources/json/PBACDefaults_config.json
+++ b/resources/json/PBACDefaults_config.json
@@ -10,6 +10,7 @@
             "_id": "submission_request:view",
             "group": "Submission Request Permissions",
             "name": "View",
+            "order": 1,
             "checked": true,
             "disabled": false
           },
@@ -17,6 +18,7 @@
             "_id": "submission_request:create",
             "group": "Submission Request Permissions",
             "name": "Create",
+            "order": 2,
             "checked": false,
             "disabled": false
           },
@@ -24,6 +26,7 @@
             "_id": "submission_request:review",
             "group": "Submission Request Permissions",
             "name": "Review",
+            "order": 4,
             "checked": false,
             "disabled": false
           },
@@ -31,6 +34,7 @@
             "_id": "submission_request:submit",
             "group": "Submission Request Permissions",
             "name": "Submit",
+            "order": 3,
             "checked": false,
             "disabled": false
           },
@@ -38,6 +42,7 @@
             "_id": "submission_request:delete",
             "group": "Submission Request Permissions",
             "name": "Cancel/Restore",
+            "order": 5,
             "checked": true,
             "disabled": false
           },
@@ -234,6 +239,7 @@
             "_id": "submission_request:view",
             "group": "Submission Request Permissions",
             "name": "View",
+            "order": 1,
             "checked": false,
             "disabled": false
           },
@@ -241,6 +247,7 @@
             "_id": "submission_request:create",
             "group": "Submission Request Permissions",
             "name": "Create",
+            "order": 2,
             "checked": false,
             "disabled": false
           },
@@ -248,6 +255,7 @@
             "_id": "submission_request:review",
             "group": "Submission Request Permissions",
             "name": "Review",
+            "order": 4,
             "checked": false,
             "disabled": false
           },
@@ -255,6 +263,7 @@
             "_id": "submission_request:submit",
             "group": "Submission Request Permissions",
             "name": "Submit",
+            "order": 3,
             "checked": false,
             "disabled": false
           },
@@ -262,6 +271,7 @@
             "_id": "submission_request:delete",
             "group": "Submission Request Permissions",
             "name": "Cancel/Restore",
+            "order": 5,
             "checked": false,
             "disabled": false
           },
@@ -458,6 +468,7 @@
             "_id": "submission_request:view",
             "group": "Submission Request Permissions",
             "name": "View",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -465,6 +476,7 @@
             "_id": "submission_request:create",
             "group": "Submission Request Permissions",
             "name": "Create",
+            "order": 2,
             "checked": false,
             "disabled": true
           },
@@ -472,6 +484,7 @@
             "_id": "submission_request:review",
             "group": "Submission Request Permissions",
             "name": "Review",
+            "order": 4,
             "checked": false,
             "disabled": true
           },
@@ -479,6 +492,7 @@
             "_id": "submission_request:submit",
             "group": "Submission Request Permissions",
             "name": "Submit",
+            "order": 3,
             "checked": false,
             "disabled": true
           },
@@ -486,6 +500,7 @@
             "_id": "submission_request:delete",
             "group": "Submission Request Permissions",
             "name": "Cancel/Restore",
+            "order": 5,
             "checked": false,
             "disabled": false
           },
@@ -682,6 +697,7 @@
             "_id": "submission_request:view",
             "group": "Submission Request Permissions",
             "name": "View",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -689,6 +705,7 @@
             "_id": "submission_request:create",
             "group": "Submission Request Permissions",
             "name": "Create",
+            "order": 2,
             "checked": true,
             "disabled": true
           },
@@ -696,6 +713,7 @@
             "_id": "submission_request:review",
             "group": "Submission Request Permissions",
             "name": "Review",
+            "order": 4,
             "checked": false,
             "disabled": true
           },
@@ -703,6 +721,7 @@
             "_id": "submission_request:submit",
             "group": "Submission Request Permissions",
             "name": "Submit",
+            "order": 3,
             "checked": true,
             "disabled": true
           },
@@ -710,6 +729,7 @@
             "_id": "submission_request:delete",
             "group": "Submission Request Permissions",
             "name": "Cancel/Restore",
+            "order": 5,
             "checked": true,
             "disabled": true
           },
@@ -906,6 +926,7 @@
             "_id": "submission_request:view",
             "group": "Submission Request Permissions",
             "name": "View",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -913,6 +934,7 @@
             "_id": "submission_request:create",
             "group": "Submission Request Permissions",
             "name": "Create",
+            "order": 2,
             "checked": true,
             "disabled": true
           },
@@ -920,6 +942,7 @@
             "_id": "submission_request:review",
             "group": "Submission Request Permissions",
             "name": "Review",
+            "order": 4,
             "checked": false,
             "disabled": true
           },
@@ -927,6 +950,7 @@
             "_id": "submission_request:submit",
             "group": "Submission Request Permissions",
             "name": "Submit",
+            "order": 3,
             "checked": true,
             "disabled": true
           },
@@ -934,6 +958,7 @@
             "_id": "submission_request:delete",
             "group": "Submission Request Permissions",
             "name": "Cancel/Restore",
+            "order": 5,
             "checked": true,
             "disabled": true
           },

--- a/resources/json/PBACDefaults_config.json
+++ b/resources/json/PBACDefaults_config.json
@@ -172,6 +172,7 @@
             "_id": "data_submission:submitted",
             "group": "Data Submission Emails",
             "name": "When submitted",
+            "order": 1,
             "checked": false,
             "disabled": false
           },
@@ -179,6 +180,7 @@
             "_id": "data_submission:cancelled",
             "group": "Data Submission Emails",
             "name": "When cancelled",
+            "order": 2,
             "checked": false,
             "disabled": false
           },
@@ -186,6 +188,7 @@
             "_id": "data_submission:withdrawn",
             "group": "Data Submission Emails",
             "name": "When withdrawn",
+            "order": 3,
             "checked": false,
             "disabled": false
           },
@@ -193,13 +196,15 @@
             "_id": "data_submission:released",
             "group": "Data Submission Emails",
             "name": "When released",
+            "order": 5,
             "checked": false,
             "disabled": false
           },
           {
             "_id": "data_submission:rejected",
             "group": "Data Submission Emails",
-            "name": "When rejected ",
+            "name": "When rejected",
+            "order": 4,
             "checked": false,
             "disabled": false
           },
@@ -207,6 +212,7 @@
             "_id": "data_submission:completed",
             "group": "Data Submission Emails",
             "name": "When completed",
+            "order": 6,
             "checked": false,
             "disabled": false
           },
@@ -214,6 +220,7 @@
             "_id": "data_submission:expiring",
             "group": "Data Submission Emails",
             "name": "When expiring",
+            "order": 7,
             "checked": false,
             "disabled": false
           },
@@ -221,27 +228,31 @@
             "_id": "data_submission:deleted",
             "group": "Data Submission Emails",
             "name": "When deleted",
+            "order": 8,
             "checked": false,
             "disabled": false
           },
           {
             "_id": "access:requested",
             "group": "Miscellaneous",
-            "name": "User Request Access",
+            "name": "Request Access",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
           {
             "_id": "account:inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (individual)",
+            "name": "Account Disabled",
+            "order": 2,
             "checked": true,
             "disabled": true
           },
           {
             "_id": "account:users_inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (consolidated)",
+            "name": "Account Disabled (Consolidated)",
+            "order": 3,
             "checked": false,
             "disabled": true
           }
@@ -416,6 +427,7 @@
             "_id": "data_submission:submitted",
             "group": "Data Submission Emails",
             "name": "When submitted",
+            "order": 1,
             "checked": true,
             "disabled": false
           },
@@ -423,6 +435,7 @@
             "_id": "data_submission:cancelled",
             "group": "Data Submission Emails",
             "name": "When cancelled",
+            "order": 2,
             "checked": true,
             "disabled": false
           },
@@ -430,6 +443,7 @@
             "_id": "data_submission:withdrawn",
             "group": "Data Submission Emails",
             "name": "When withdrawn",
+            "order": 3,
             "checked": true,
             "disabled": false
           },
@@ -437,13 +451,15 @@
             "_id": "data_submission:released",
             "group": "Data Submission Emails",
             "name": "When released",
+            "order": 5,
             "checked": true,
             "disabled": false
           },
           {
             "_id": "data_submission:rejected",
             "group": "Data Submission Emails",
-            "name": "When rejected ",
+            "name": "When rejected",
+            "order": 4,
             "checked": true,
             "disabled": false
           },
@@ -451,6 +467,7 @@
             "_id": "data_submission:completed",
             "group": "Data Submission Emails",
             "name": "When completed",
+            "order": 6,
             "checked": true,
             "disabled": false
           },
@@ -458,6 +475,7 @@
             "_id": "data_submission:expiring",
             "group": "Data Submission Emails",
             "name": "When expiring",
+            "order": 7,
             "checked": true,
             "disabled": false
           },
@@ -465,27 +483,31 @@
             "_id": "data_submission:deleted",
             "group": "Data Submission Emails",
             "name": "When deleted",
+            "order": 8,
             "checked": true,
             "disabled": false
           },
           {
             "_id": "access:requested",
             "group": "Miscellaneous",
-            "name": "User Request Access",
+            "name": "Request Access",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
           {
             "_id": "account:inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (individual)",
+            "name": "Account Disabled",
+            "order": 2,
             "checked": true,
             "disabled": true
           },
           {
             "_id": "account:users_inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (consolidated)",
+            "name": "Account Disabled (Consolidated)",
+            "order": 3,
             "checked": false,
             "disabled": true
           }
@@ -660,6 +682,7 @@
             "_id": "data_submission:submitted",
             "group": "Data Submission Emails",
             "name": "When submitted",
+            "order": 1,
             "checked": false,
             "disabled": false
           },
@@ -667,6 +690,7 @@
             "_id": "data_submission:cancelled",
             "group": "Data Submission Emails",
             "name": "When cancelled",
+            "order": 2,
             "checked": true,
             "disabled": false
           },
@@ -674,6 +698,7 @@
             "_id": "data_submission:withdrawn",
             "group": "Data Submission Emails",
             "name": "When withdrawn",
+            "order": 3,
             "checked": false,
             "disabled": false
           },
@@ -681,13 +706,15 @@
             "_id": "data_submission:released",
             "group": "Data Submission Emails",
             "name": "When released",
+            "order": 5,
             "checked": true,
             "disabled": false
           },
           {
             "_id": "data_submission:rejected",
             "group": "Data Submission Emails",
-            "name": "When rejected ",
+            "name": "When rejected",
+            "order": 4,
             "checked": false,
             "disabled": false
           },
@@ -695,6 +722,7 @@
             "_id": "data_submission:completed",
             "group": "Data Submission Emails",
             "name": "When completed",
+            "order": 6,
             "checked": true,
             "disabled": false
           },
@@ -702,6 +730,7 @@
             "_id": "data_submission:expiring",
             "group": "Data Submission Emails",
             "name": "When expiring",
+            "order": 7,
             "checked": true,
             "disabled": false
           },
@@ -709,27 +738,31 @@
             "_id": "data_submission:deleted",
             "group": "Data Submission Emails",
             "name": "When deleted",
+            "order": 8,
             "checked": true,
             "disabled": false
           },
           {
             "_id": "access:requested",
             "group": "Miscellaneous",
-            "name": "User Request Access",
+            "name": "Request Access",
+            "order": 1,
             "checked": true,
             "disabled": false
           },
           {
             "_id": "account:inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (individual)",
+            "name": "Account Disabled",
+            "order": 2,
             "checked": false,
             "disabled": true
           },
           {
             "_id": "account:users_inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (consolidated)",
+            "name": "Account Disabled (Consolidated)",
+            "order": 3,
             "checked": true,
             "disabled": true
           }
@@ -904,6 +937,7 @@
             "_id": "data_submission:submitted",
             "group": "Data Submission Emails",
             "name": "When submitted",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -911,6 +945,7 @@
             "_id": "data_submission:cancelled",
             "group": "Data Submission Emails",
             "name": "When cancelled",
+            "order": 2,
             "checked": true,
             "disabled": true
           },
@@ -918,6 +953,7 @@
             "_id": "data_submission:withdrawn",
             "group": "Data Submission Emails",
             "name": "When withdrawn",
+            "order": 3,
             "checked": true,
             "disabled": true
           },
@@ -925,13 +961,15 @@
             "_id": "data_submission:released",
             "group": "Data Submission Emails",
             "name": "When released",
+            "order": 5,
             "checked": true,
             "disabled": true
           },
           {
             "_id": "data_submission:rejected",
             "group": "Data Submission Emails",
-            "name": "When rejected ",
+            "name": "When rejected",
+            "order": 4,
             "checked": true,
             "disabled": true
           },
@@ -939,6 +977,7 @@
             "_id": "data_submission:completed",
             "group": "Data Submission Emails",
             "name": "When completed",
+            "order": 6,
             "checked": true,
             "disabled": true
           },
@@ -946,6 +985,7 @@
             "_id": "data_submission:expiring",
             "group": "Data Submission Emails",
             "name": "When expiring",
+            "order": 7,
             "checked": true,
             "disabled": true
           },
@@ -953,27 +993,31 @@
             "_id": "data_submission:deleted",
             "group": "Data Submission Emails",
             "name": "When deleted",
+            "order": 8,
             "checked": true,
             "disabled": true
           },
           {
             "_id": "access:requested",
             "group": "Miscellaneous",
-            "name": "User Request Access",
+            "name": "Request Access",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
           {
             "_id": "account:inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (individual)",
+            "name": "Account Disabled",
+            "order": 2,
             "checked": true,
             "disabled": true
           },
           {
             "_id": "account:users_inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (consolidated)",
+            "name": "Account Disabled (Consolidated)",
+            "order": 3,
             "checked": false,
             "disabled": true
           }
@@ -1148,6 +1192,7 @@
             "_id": "data_submission:submitted",
             "group": "Data Submission Emails",
             "name": "When submitted",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
@@ -1155,6 +1200,7 @@
             "_id": "data_submission:cancelled",
             "group": "Data Submission Emails",
             "name": "When cancelled",
+            "order": 2,
             "checked": false,
             "disabled": true
           },
@@ -1162,6 +1208,7 @@
             "_id": "data_submission:withdrawn",
             "group": "Data Submission Emails",
             "name": "When withdrawn",
+            "order": 3,
             "checked": false,
             "disabled": true
           },
@@ -1169,13 +1216,15 @@
             "_id": "data_submission:released",
             "group": "Data Submission Emails",
             "name": "When released",
+            "order": 5,
             "checked": false,
             "disabled": true
           },
           {
             "_id": "data_submission:rejected",
             "group": "Data Submission Emails",
-            "name": "When rejected ",
+            "name": "When rejected",
+            "order": 4,
             "checked": false,
             "disabled": true
           },
@@ -1183,6 +1232,7 @@
             "_id": "data_submission:completed",
             "group": "Data Submission Emails",
             "name": "When completed",
+            "order": 6,
             "checked": false,
             "disabled": true
           },
@@ -1190,34 +1240,39 @@
             "_id": "data_submission:expiring",
             "group": "Data Submission Emails",
             "name": "When expiring",
+            "order": 7,
             "checked": false,
             "disabled": true
           },
           {
             "_id": "data_submission:deleted",
-            "group": "Data Submission Permissions",
+            "group": "Data Submission Emails",
             "name": "When deleted",
+            "order": 8,
             "checked": false,
             "disabled": true
           },
           {
             "_id": "access:requested",
             "group": "Miscellaneous",
-            "name": "User Request Access",
+            "name": "Request Access",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
           {
             "_id": "account:inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (individual)",
+            "name": "Account Disabled",
+            "order": 2,
             "checked": true,
             "disabled": true
           },
           {
             "_id": "account:users_inactivated",
             "group": "Miscellaneous",
-            "name": "Account Disabled due to inactivity (consolidated)",
+            "name": "Account Disabled (Consolidated)",
+            "order": 3,
             "checked": false,
             "disabled": true
           }

--- a/resources/json/PBACDefaults_config.json
+++ b/resources/json/PBACDefaults_config.json
@@ -98,6 +98,7 @@
             "_id": "user:manage",
             "group": "Admin Permissions",
             "name": "Manage User",
+            "order": 3,
             "checked": false,
             "disabled": false
           },
@@ -105,6 +106,7 @@
             "_id": "program:manage",
             "group": "Admin Permissions",
             "name": "Manage Program",
+            "order": 1,
             "checked": false,
             "disabled": false
           },
@@ -112,6 +114,7 @@
             "_id": "study:manage",
             "group": "Admin Permissions",
             "name": "Manage Study",
+            "order": 2,
             "checked": false,
             "disabled": false
           },
@@ -119,6 +122,7 @@
             "_id": "dashboard:view",
             "group": "Admin Permissions",
             "name": "View Operation Dashboard",
+            "order": 4,
             "checked": true,
             "disabled": false
           }
@@ -333,6 +337,7 @@
             "_id": "user:manage",
             "group": "Admin Permissions",
             "name": "Manage User",
+            "order": 3,
             "checked": false,
             "disabled": true
           },
@@ -340,6 +345,7 @@
             "_id": "program:manage",
             "group": "Admin Permissions",
             "name": "Manage Program",
+            "order": 1,
             "checked": false,
             "disabled": false
           },
@@ -347,6 +353,7 @@
             "_id": "study:manage",
             "group": "Admin Permissions",
             "name": "Manage Study",
+            "order": 2,
             "checked": false,
             "disabled": false
           },
@@ -354,6 +361,7 @@
             "_id": "dashboard:view",
             "group": "Admin Permissions",
             "name": "View Operation Dashboard",
+            "order": 4,
             "checked": true,
             "disabled": false
           }
@@ -568,6 +576,7 @@
             "_id": "user:manage",
             "group": "Admin Permissions",
             "name": "Manage User",
+            "order": 3,
             "checked": true,
             "disabled": true
           },
@@ -575,6 +584,7 @@
             "_id": "program:manage",
             "group": "Admin Permissions",
             "name": "Manage Program",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -582,6 +592,7 @@
             "_id": "study:manage",
             "group": "Admin Permissions",
             "name": "Manage Study",
+            "order": 2,
             "checked": true,
             "disabled": true
           },
@@ -589,6 +600,7 @@
             "_id": "dashboard:view",
             "group": "Admin Permissions",
             "name": "View Operation Dashboard",
+            "order": 4,
             "checked": true,
             "disabled": true
           }
@@ -803,6 +815,7 @@
             "_id": "user:manage",
             "group": "Admin Permissions",
             "name": "Manage User",
+            "order": 3,
             "checked": false,
             "disabled": true
           },
@@ -810,6 +823,7 @@
             "_id": "program:manage",
             "group": "Admin Permissions",
             "name": "Manage Program",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
@@ -817,6 +831,7 @@
             "_id": "study:manage",
             "group": "Admin Permissions",
             "name": "Manage Study",
+            "order": 2,
             "checked": false,
             "disabled": true
           },
@@ -824,6 +839,7 @@
             "_id": "dashboard:view",
             "group": "Admin Permissions",
             "name": "View Operation Dashboard",
+            "order": 4,
             "checked": false,
             "disabled": true
           }
@@ -1038,6 +1054,7 @@
             "_id": "user:manage",
             "group": "Admin Permissions",
             "name": "Manage User",
+            "order": 3,
             "checked": false,
             "disabled": true
           },
@@ -1045,6 +1062,7 @@
             "_id": "program:manage",
             "group": "Admin Permissions",
             "name": "Manage Program",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
@@ -1052,6 +1070,7 @@
             "_id": "study:manage",
             "group": "Admin Permissions",
             "name": "Manage Study",
+            "order": 2,
             "checked": false,
             "disabled": true
           },
@@ -1059,6 +1078,7 @@
             "_id": "dashboard:view",
             "group": "Admin Permissions",
             "name": "View Operation Dashboard",
+            "order": 4,
             "checked": false,
             "disabled": true
           }

--- a/resources/json/PBACDefaults_config.json
+++ b/resources/json/PBACDefaults_config.json
@@ -50,6 +50,7 @@
             "_id": "access:request",
             "group": "Miscellaneous",
             "name": "Request Access",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
@@ -279,6 +280,7 @@
             "_id": "access:request",
             "group": "Miscellaneous",
             "name": "Request Access",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
@@ -508,6 +510,7 @@
             "_id": "access:request",
             "group": "Miscellaneous",
             "name": "Request Access",
+            "order": 1,
             "checked": false,
             "disabled": true
           },
@@ -737,6 +740,7 @@
             "_id": "access:request",
             "group": "Miscellaneous",
             "name": "Request Access",
+            "order": 1,
             "checked": true,
             "disabled": true
           },
@@ -966,6 +970,7 @@
             "_id": "access:request",
             "group": "Miscellaneous",
             "name": "Request Access",
+            "order": 1,
             "checked": true,
             "disabled": true
           },


### PR DESCRIPTION
### Overview

This PR updates the PBACDefaults JSON file for the new `order` numerical property. It also includes updates to fix outdated names.

### Change Details (Specifics)

- Add `order` property to all PBAC options, based on [CRDCDH-1886](https://tracker.nci.nih.gov/browse/CRDCDH-1886)
- Update the outdated visual name for emails: `access:requested`, `account:inactivated`, and `account:users_inactivated`
- Update the incorrect Group Name for Email Notification `data_submission:deleted` for the `User` role

### Related Ticket(s)

N/A – Many PBAC tickets