### PR TITLE
Enable heartbeat for metadata

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -193,7 +193,7 @@ const ERROR = {
     INVALID_PRIMARY_CONTACT: "No data concierge found with the data concierge ID",
     INVALID_PRIMARY_CONTACT_ROLE: "The user role for a data concierge must be Data Commons Personnel",
     INVALID_PRIMARY_CONTACT_ATTEMPT: "Please, do not provide the data concierge ID when the useProgramPC is true.",
-    UPLOADING_BATCH_CRASHED: "CLI stopped responding while uploading data files.",
+    UPLOADING_BATCH_CRASHED: "CLI stopped responding while uploading files.",
     UPLOADING_BATCH_INTERRUPTED: 'File uploading is interrupted.',
     FAILED_UPDATE_BATCH_STATUS: "Failed to update the batch status.",
     FILE_NOT_EXIST: "The File requested does not exist.",

--- a/services/submission.js
+++ b/services/submission.js
@@ -281,21 +281,19 @@ class Submission {
             return {}
         }
         else {
-            if (aBatch.type === VALIDATION.TYPES.DATA_FILE) {
-                // remove uploading batch from the uploading batch pool if uploading is completed or failed
-                this.uploadingMonitor.removeUploadingBatch(aBatch._id);
-                // check files if any success == false and error contains 'File uploading is interrupted.'
-                if (params?.files?.some((file) => file?.succeeded === false && file?.errors?.includes(ERROR.UPLOADING_BATCH_INTERRUPTED))) {
-                    // update the batch status to failed
-                    await this.uploadingMonitor.setUploadingFailed(aBatch._id, BATCH.STATUSES.FAILED, ERROR.UPLOADING_BATCH_INTERRUPTED, true);
-                    return {
-                        _id: aBatch._id,
-                        submissionID: aBatch.submissionID,
-                        type: aBatch.type,
-                        fileCount: aBatch.fileCount,
-                        status: BATCH.STATUSES.FAILED,
-                        updatedAt: getCurrentTime(),
-                    }
+            // remove uploading batch from the uploading batch pool if uploading is completed or failed
+            this.uploadingMonitor.removeUploadingBatch(aBatch._id);
+            // check files if any success == false and error contains 'File uploading is interrupted.'
+            if (params?.files?.some((file) => file?.succeeded === false && file?.errors?.includes(ERROR.UPLOADING_BATCH_INTERRUPTED))) {
+                // update the batch status to failed
+                await this.uploadingMonitor.setUploadingFailed(aBatch._id, BATCH.STATUSES.FAILED, ERROR.UPLOADING_BATCH_INTERRUPTED, true);
+                return {
+                    _id: aBatch._id,
+                    submissionID: aBatch.submissionID,
+                    type: aBatch.type,
+                    fileCount: aBatch.fileCount,
+                    status: BATCH.STATUSES.FAILED,
+                    updatedAt: getCurrentTime(),
                 }
             }
         }


### PR DESCRIPTION
Updated submission.js and error constants to enable heartbeat for metadata uploading.