### PR TITLE
CRDCDH-2998

### DIFF
--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -794,7 +794,8 @@ type Query {
         submissionID: String!,
         apiURL: String!,
         dataFolder: String = "/Users/my_name/my_files",
-        manifest: String = "/Users/my_name/my_manifest.tsv"
+        manifest: String = "/Users/my_name/my_manifest.tsv",
+        archive_manifest: String = "/Users/my_name/my_archive_manifest.tsv"
     ): String
 
     listInstitutions(

--- a/resources/yaml/data_file_upload_config.yaml
+++ b/resources/yaml/data_file_upload_config.yaml
@@ -11,6 +11,8 @@ Config:
     data: {dataFolder}
     #path to manifest file, conditional required when type = file
     manifest: {manifest}
+     # path to archive manifest file, conditional required when uploading any zipped (.zip) data files.
+    archive_manifest: {archive_manifest}
     #file uploading retries
     retries: 3
     # if overwrite existed file

--- a/services/submission.js
+++ b/services/submission.js
@@ -1029,7 +1029,8 @@ class Submission {
         //set parameters
         const parameters = {submissionID: params.submissionID, apiURL: params.apiURL, 
             dataFolder: (params.dataFolder)?  params.dataFolder : "/Users/my_name/my_files",
-            manifest: (params.manifest)? params.manifest: "/Users/my_name/my_manifest.tsv"
+            manifest: (params.manifest)? params.manifest: "/Users/my_name/my_manifest.tsv",
+            archive_manifest: (params.archive_manifest)? params.archive_manifest: "/Users/my_name/my_archive_manifest.tsv"
         }
         //get the uploader CLI config template as string
         var configString = this.uploaderCLIConfigs;

--- a/test/services/submission.getUploaderCLIConfig.test.js
+++ b/test/services/submission.getUploaderCLIConfig.test.js
@@ -1,0 +1,140 @@
+const {Submission} = require('../../services/submission');
+
+describe('Submission.getUploaderCLIConfigs', () => {
+    let submission;
+    let mockSubmissionDAO;
+    let mockContext;
+    let mockSubmission;
+    let mockUploaderCLIConfigs;
+    let mockFetchDataModelInfo;
+    let mockReplaceToken;
+
+    beforeEach(() => {
+        mockSubmission = {
+            _id: 'sub1',
+            dataCommons: 'commons1'
+        };
+
+        mockSubmissionDAO = {
+            findById: jest.fn()
+        };
+
+        mockUploaderCLIConfigs = 'submissionID: {submissionID}\napiURL: {apiURL}\ndataFolder: {dataFolder}\nmanifest: {manifest}\narchive_manifest: {archive_manifest}\ntoken: {token}';
+
+        mockFetchDataModelInfo = jest.fn().mockResolvedValue({ commons1: {} });
+        mockReplaceToken = jest.fn().mockImplementation(async (context, configString) => configString.replace('{token}', 'mocked-token'));
+
+        submission = new Submission();
+        submission.submissionDAO = mockSubmissionDAO;
+        submission.uploaderCLIConfigs = mockUploaderCLIConfigs;
+        submission.fetchDataModelInfo = mockFetchDataModelInfo;
+        submission._replaceToken = mockReplaceToken;
+        submission._verifyBatchPermission = jest.fn();
+
+        global.verifySession = jest.fn(() => ({
+            verifyInitialized: jest.fn()
+        }));
+
+        global.ERROR = {
+            INVALID_SUBMISSION_NOT_FOUND: 'Cant find the submission by submissionID'
+        };
+
+        mockContext = {
+            userInfo: {
+                _id: 'user1'
+            }
+        };
+    });
+
+    it('should return formatted config string with all parameters', async () => {
+        mockSubmissionDAO.findById.mockResolvedValue(mockSubmission);
+
+        // Patch String.prototype.format for the test
+        String.prototype.format = function(params) {
+            let str = this;
+            for (const key in params) {
+                str = str.replace(new RegExp(`{${key}}`, 'g'), params[key]);
+            }
+            return str;
+        };
+
+        const params = {
+            submissionID: 'sub1',
+            apiURL: 'http://api.example.com',
+            dataFolder: '/tmp/data',
+            manifest: '/tmp/manifest.tsv',
+            archive_manifest: '/tmp/archive_manifest.tsv'
+        };
+
+        const result = await submission.getUploaderCLIConfigs(params, mockContext);
+
+        expect(mockSubmissionDAO.findById).toHaveBeenCalledWith('sub1');
+        expect(submission._verifyBatchPermission).toHaveBeenCalledWith(mockSubmission, 'user1');
+        expect(submission.fetchDataModelInfo).toHaveBeenCalled();
+        expect(submission._replaceToken).toHaveBeenCalled();
+        expect(result).toContain('submissionID: sub1');
+        expect(result).toContain('apiURL: http://api.example.com');
+        expect(result).toContain('dataFolder: /tmp/data');
+        expect(result).toContain('manifest: /tmp/manifest.tsv');
+        expect(result).toContain('archive_manifest: /tmp/archive_manifest.tsv');
+        expect(result).toContain('token: mocked-token');
+    });
+
+    it('should use default values for missing optional params', async () => {
+        mockSubmissionDAO.findById.mockResolvedValue(mockSubmission);
+
+        String.prototype.format = function(params) {
+            let str = this;
+            for (const key in params) {
+                str = str.replace(new RegExp(`{${key}}`, 'g'), params[key]);
+            }
+            return str;
+        };
+
+        const params = {
+            submissionID: 'sub1',
+            apiURL: 'http://api.example.com'
+            // dataFolder, manifest, archive_manifest are missing
+        };
+
+        const result = await submission.getUploaderCLIConfigs(params, mockContext);
+
+        expect(result).toContain('dataFolder: /Users/my_name/my_files');
+        expect(result).toContain('manifest: /Users/my_name/my_manifest.tsv');
+        expect(result).toContain('archive_manifest: /Users/my_name/my_archive_manifest.tsv');
+    });
+
+    it('should throw error if submission not found', async () => {
+        mockSubmissionDAO.findById.mockResolvedValue(null);
+
+        const params = {
+            submissionID: 'sub1',
+            apiURL: 'http://api.example.com'
+        };
+
+        await expect(submission.getUploaderCLIConfigs(params, mockContext))
+            .rejects
+            .toThrow('Cant find the submission by submissionID');
+    });
+
+    it('should call _verifyBatchPermission with correct arguments', async () => {
+        mockSubmissionDAO.findById.mockResolvedValue(mockSubmission);
+
+        String.prototype.format = function(params) {
+            let str = this;
+            for (const key in params) {
+                str = str.replace(new RegExp(`{${key}}`, 'g'), params[key]);
+            }
+            return str;
+        };
+
+        const params = {
+            submissionID: 'sub1',
+            apiURL: 'http://api.example.com'
+        };
+
+        await submission.getUploaderCLIConfigs(params, mockContext);
+
+        expect(submission._verifyBatchPermission).toHaveBeenCalledWith(mockSubmission, 'user1');
+    });
+});


### PR DESCRIPTION
Implemented CRDCDH-2998.
1) Update the definition of API, retrieveCLIConfig, as listed below:
    retrieveCLIConfig(
        submissionID: String!,
        apiURL: String!,
        dataFolder: String = "/Users/my_name/my_files",
        manifest: String = "/Users/my_name/my_manifest.tsv",
        archive_manifest: String = "/Users/my_name/my_archive_manifest.tsv"
    ): String

2) update the API implementation in submission service, getUploaderCLIConfigs.
3) create unit tests on getUploaderCLIConfigs