### PR TITLE
Remove duplication router

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -238,6 +238,7 @@ const ERROR = {
     SAMPLE_NOT_FOUND: "This Data Submission has no [sample OR participant] records uploaded. Unable to generate the dbGaP loading sheets at this time.",
     PARTICIPANT_SAMPLE_NOT_FOUND: "This Data Submission currently has no sample records with a link to a participant record. Unable to generate the dbGaP loading sheets at this time.",
     FAILED_CREATE_LOAD_SHEET: "An unknown error occurred while generating the dbGaP Loading Sheets. Please try again later.",
+    USER_NOT_EXIST: "The user does not exist.",
 }
 
 module.exports = ERROR;

--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -241,7 +241,6 @@ dbConnector.connect().then(async () => {
         getSubmissionAttributes: submissionService.getSubmissionAttributes.bind(submissionService),
         listReleasedStudies: releaseService.listReleasedStudies.bind(releaseService),
         getReleaseNodeTypes: releaseService.getReleaseNodeTypes.bind(releaseService),
-        downloadDBGaPLoadSheet : submissionService.downloadDBGaPLoadSheet.bind(submissionService),
         getPendingPVs: submissionService.getPendingPVs.bind(submissionService),
         listReleasedDataRecords: releaseService.listReleasedDataRecords.bind(releaseService),
         retrievePropsForNodeType: releaseService.getPropsForNodeType.bind(releaseService),


### PR DESCRIPTION
Remove the duplicate route for downloadDBGaPLoadSheet.
Added an error constant, USER_NOT_EXIST: "The user does not exist.",