### PR TITLE
Make temp credential valid for 12 hr.

### DIFF
--- a/services/aws-request.js
+++ b/services/aws-request.js
@@ -58,12 +58,14 @@ class AWSService {
             });
         });
 
-        console.log("Temporary credentials obtained successfully");
-        const now = new Date();
-        const expiration = result.expiration;
-        const durationHours =
-            (expiration.getTime() - now.getTime()) / 1000 / 3600;
-        console.log("Token is valid for:", durationHours.toFixed(2), "hours");
+        const expiration = result?.expiration;
+        if (expiration) {
+            console.log("Temporary credentials obtained successfully");
+            const now = new Date();
+            const durationHours =
+                (expiration.getTime() - now.getTime()) / 1000 / 3600;
+            console.log("Token is valid for:", durationHours.toFixed(2), "hours");
+        }
         return result;
     }
 

--- a/services/aws-request.js
+++ b/services/aws-request.js
@@ -58,18 +58,13 @@ class AWSService {
             });
         });
 
-        if (result) {
-            console.log("Temporary credentials obtained successfully");
-            const now = new Date();
-            const expiration = result.expiration;
-            const durationHours =
-                (expiration.getTime() - now.getTime()) / 1000 / 3600;
-            console.log("Token is valid for:", durationHours.toFixed(2), "hours");
-            return result;
-        } else {
-            console.error("No credentials returned from assumeRole");
-            throw new Error("Failed to create temporary credentials");
-        }
+        console.log("Temporary credentials obtained successfully");
+        const now = new Date();
+        const expiration = result.expiration;
+        const durationHours =
+            (expiration.getTime() - now.getTime()) / 1000 / 3600;
+        console.log("Token is valid for:", durationHours.toFixed(2), "hours");
+        return result;
     }
 
     /**


### PR DESCRIPTION
Minor change to set durationSeconds to 12 hours.  and passed testing as shown in console log:
Temporary credentials obtained successfully
Token is valid for: 12.00 hours