### PR TITLE
Fix application not found error handling in tests

### DIFF
--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -255,10 +255,10 @@ class ApprovedStudiesService {
             GPAName
         } = this._verifyAndFormatStudyParams(params);
         let updateStudy = await this.approvedStudyDAO.findFirst({id: studyID});
-        const {isPendingGPA: currPendingGPA, dbGaPID: currDbGaPID} = updateStudy;
         if (!updateStudy) {
             throw new Error(ERROR.APPROVED_STUDY_NOT_FOUND);
         }
+        const {isPendingGPA: currPendingGPA, dbGaPID: currDbGaPID} = updateStudy;
 
         // check if name is unique
         if (name !== updateStudy.studyName)

--- a/test/services/application.test.js
+++ b/test/services/application.test.js
@@ -2,6 +2,9 @@ const {Application} = require('../../services/application'); // Adjust if needed
 const ApplicationDAO = require('../../dao/application');
 const USER_PERMISSION_CONSTANTS = require("../../crdc-datahub-database-drivers/constants/user-permission-constants");
 
+// Mock ApplicationDAO
+jest.mock('../../dao/application');
+
 // Mocks for dependencies
 const mockLogCollection = { insert: jest.fn() };
 const mockApplicationCollection = {
@@ -323,11 +326,10 @@ describe('Application', () => {
             userScopeMock.isAllScope.mockReturnValue(false);
             userScopeMock.isOwnScope.mockReturnValue(true);
             const params = { application: { _id: 'app1' } };
-            mockApplicationCollection.find.mockResolvedValue([{ _id: 'app1', applicant: { applicantID: 'user1' }, status: NEW }]);
+            // Mock ApplicationDAO.findFirst to return null (application not found)
+            ApplicationDAO.prototype.findFirst = jest.fn().mockResolvedValue(null);
             mockConfigurationService.findByType.mockResolvedValue({ current: '2.0', new: '3.0' });
-            // Patch: updateApplication must be a real function, not a global mock, for this test
-            global.updateApplication = jest.fn().mockResolvedValue({ _id: 'app1', status: IN_PROGRESS });
-            await expect(app.saveApplication(params, context)).rejects.toThrow(ERROR.VERIFY.APPLICATION_NOT_FOUND);
+            await expect(app.saveApplication(params, context)).rejects.toThrow(ERROR.APPLICATION_NOT_FOUND);
         });
 
         it('throws if not owner', async () => {


### PR DESCRIPTION
Updated the application service test to mock ApplicationDAO.findFirst returning null and expect the correct APPLICATION_NOT_FOUND error. Also fixed the order of property access in ApprovedStudiesService to avoid referencing undefined variables.