### PR TITLE
Update PBAC defaults

### DIFF
--- a/resources/json/PBACDefaults_config.json
+++ b/resources/json/PBACDefaults_config.json
@@ -747,7 +747,7 @@
             "inherited": ["data_submission:view:all"],
             "name": "Review",
             "order": 4,
-            "checked": false,
+            "checked": true,
             "disabled": false
           },
           {


### PR DESCRIPTION
Updated the PBACDefaults_config.json to have the 'Review' permission checked by default instead of unchecked.