### PR TITLE
Add dataCommons check to cross validation logic

### DIFF
--- a/dao/dataRecords.js
+++ b/dao/dataRecords.js
@@ -121,7 +121,7 @@ class DataRecordDAO extends GenericDAO {
     }
 
     // note: use MongoDB because Prisma has to fetch all matching documents into memory before grouping and paginating
-    async submissionCrossValidationResults(submissionID, nodeTypes, batchIDs, severities, first, offset, orderBy, sortDirection){
+    async submissionCrossValidationResults(submissionID, nodeTypes, batchIDs, severities, first, offset, orderBy, sortDirection, dataCommons = null){
         let dataRecordQCResultsPipeline = [];
         // Filter by submission ID
         dataRecordQCResultsPipeline.push({
@@ -129,6 +129,15 @@ class DataRecordDAO extends GenericDAO {
                 submissionID: submissionID
             }
         });
+
+        // Filter by dataCommons scope for cross validation - ticket CRDCDH-3247
+        if (dataCommons) {
+            dataRecordQCResultsPipeline.push({
+                $match: {
+                    dataCommons: dataCommons
+                }
+            });
+        }
 
         // Filter by Batch IDs
         if (!!batchIDs && batchIDs.length > 0) {

--- a/services/submission.js
+++ b/services/submission.js
@@ -533,7 +533,7 @@ class Submission {
 
         const submissionAttributes = SubmissionAttributes.create(!userScope.isNoneScope(), submission, dataFileSize?.size, orphanedErrorFiles?.length > 0, uploadingBatches.length > 0);
         verifier.isValidSubmitAction(!userScope.isNoneScope(), submission, params?.comment, submissionAttributes);
-        await this._isValidReleaseAction(action, submission?._id, submission?.studyID, submission?.crossSubmissionStatus);
+        await this._isValidReleaseAction(action, submission?._id, submission?.studyID, submission?.dataCommons, submission?.crossSubmissionStatus);
         //update submission
         let events = submission.history || [];
         // admin permission and submit action only can leave a comment
@@ -696,15 +696,17 @@ class Submission {
 
     }
 
-    async _isValidReleaseAction(action, submissionID, studyID, crossSubmissionStatus) {
+    // Updated to filter by both studyID and dataCommons for cross validation scope - ticket CRDCDH-3247
+    async _isValidReleaseAction(action, submissionID, studyID, dataCommons, crossSubmissionStatus) {
         if (action?.toLowerCase() === ACTIONS.RELEASE.toLowerCase()) {
             const submissions = await this.submissionDAO.findMany({
                 studyID: studyID,
+                dataCommons: dataCommons,
                 NOT: {
                     id: submissionID
                 }
             });
-            // Throw error if other submissions associated with the same study
+            // Throw error if other submissions associated with the same study AND data commons
             // are some of them are in "Submitted" status if cross submission validation is not Passed.
             if (submissions?.some(i => i?.status === SUBMITTED) && crossSubmissionStatus !== VALIDATION_STATUS.PASSED) {
                 throw new Error(ERROR.VERIFY.INVALID_RELEASE_ACTION);
@@ -759,6 +761,7 @@ class Submission {
         }
         // if the user has review permission, and the submission status is "Submitted", and aSubmission?.crossSubmissionStatus is "Error",
         // and params.types not contains CROSS_SUBMISSION, add CROSS_SUBMISSION. User story CRDCDH-2830
+        // Cross validation now only applies to submissions with same study AND data commons - ticket CRDCDH-3247
         if (reviewScope && !reviewScope.isNoneScope() && aSubmission?.status === SUBMITTED &&
             aSubmission?.crossSubmissionStatus === VALIDATION_STATUS.ERROR && params?.types &&
             !params?.types?.includes(VALIDATION.TYPES.CROSS_SUBMISSION)) {
@@ -775,7 +778,9 @@ class Submission {
         if (!validationRecord) {
             throw new Error(ERROR.FAILED_INSERT_VALIDATION_OBJECT);
         }
-        const result = await this.dataRecordService.validateMetadata(params._id, params?.types, params?.scope, validationRecord.id);
+        // Extract dataCommons for cross validation scope - ticket CRDCDH-3247
+        const dataCommons = aSubmission?.dataCommons || null;
+        const result = await this.dataRecordService.validateMetadata(params._id, params?.types, params?.scope, validationRecord.id, dataCommons);
         const updatedSubmission = await this._recordSubmissionValidation(params._id, validationRecord, params?.types, aSubmission);
         // roll back validation if service failed
         if (!result.success) {
@@ -819,7 +824,8 @@ class Submission {
         if (reviewScope.isNoneScope()) {
             throw new Error(ERROR.VERIFY.INVALID_PERMISSION)
         }
-        return this.dataRecordDAO.submissionCrossValidationResults(params.submissionID, params.nodeTypes, params.batchIDs, params.severities, params.first, params.offset, params.orderBy, params.sortDirection);
+        // Pass dataCommons for cross validation scope filtering - ticket CRDCDH-3247
+        return this.dataRecordDAO.submissionCrossValidationResults(params.submissionID, params.nodeTypes, params.batchIDs, params.severities, params.first, params.offset, params.orderBy, params.sortDirection, aSubmission?.dataCommons);
     }
 
     async listSubmissionNodeTypes(params, context) {
@@ -1957,6 +1963,8 @@ class Submission {
     // private function
     async _updateValidationStatus(types, aSubmission, metaStatus, fileStatus, crossSubmissionStatus, updatedTime, validationRecord = null) {
         const typesToUpdate = {};
+        // Cross validation status now only applies to submissions with same study AND data commons
+        // Ticket CRDCDH-3247
         if (crossSubmissionStatus && crossSubmissionStatus !== "NA" && types.includes(VALIDATION.TYPES.CROSS_SUBMISSION)) {
             typesToUpdate.crossSubmissionStatus = crossSubmissionStatus;
         }

--- a/test/integration/data-record-service.integration.test.js
+++ b/test/integration/data-record-service.integration.test.js
@@ -379,10 +379,38 @@ describe('DataRecordService Integration Tests', () => {
         'submission-123',
         [VALIDATION.TYPES.CROSS_SUBMISSION],
         null,
+        'validation-456',
+        'test-data-commons'
+      );
+
+      // Verify SQS message was sent for cross-submission validation with dataCommons
+      expect(mockAwsService.sendSQSMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'Validate Cross-submission',
+          submissionID: 'submission-123',
+          validationID: 'validation-456',
+          dataCommons: 'test-data-commons'
+        }),
+        'submission-123',
+        'submission-123',
+        'metadata-queue'
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    test('should create cross-submission validation message without dataCommons', async () => {
+      mockDataRecordsCollection.countDoc.mockResolvedValue(10);
+      mockAwsService.sendSQSMessage.mockResolvedValue({ success: true });
+
+      const result = await dataRecordService.validateMetadata(
+        'submission-123',
+        [VALIDATION.TYPES.CROSS_SUBMISSION],
+        null,
         'validation-456'
       );
 
-      // Verify SQS message was sent for cross-submission validation
+      // Verify SQS message was sent for cross-submission validation without dataCommons
       expect(mockAwsService.sendSQSMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'Validate Cross-submission',

--- a/test/services/message.test.js
+++ b/test/services/message.test.js
@@ -268,7 +268,25 @@ describe('Message Class', () => {
   });
 
   describe('Integration Tests with Real Usage Scenarios', () => {
-    test('should create metadata validation message for cross-submission', () => {
+    test('should create metadata validation message for cross-submission with dataCommons', () => {
+      const message = Message.createMetadataMessage(
+        'Validate Cross-submission',
+        'phs001234.v1.p1',
+        null,
+        'validation-2024-01-15-001',
+        'test-data-commons'
+      );
+      
+      expect(message).toMatchObject({
+        type: 'Validate Cross-submission',
+        submissionID: 'phs001234.v1.p1',
+        validationID: 'validation-2024-01-15-001',
+        dataCommons: 'test-data-commons'
+      });
+      expect(message.scope).toBeUndefined();
+    });
+
+    test('should create metadata validation message for cross-submission without dataCommons', () => {
       const message = Message.createMetadataMessage(
         'Validate Cross-submission',
         'phs001234.v1.p1',
@@ -282,6 +300,7 @@ describe('Message Class', () => {
         validationID: 'validation-2024-01-15-001'
       });
       expect(message.scope).toBeUndefined();
+      expect(message.dataCommons).toBeUndefined();
     });
 
     test('should create file validation message for individual file', () => {


### PR DESCRIPTION
Enhances cross-submission validation to filter by both study and dataCommons, addressing ticket CRDCDH-3247. Updates DAO, service, and submission logic to accept and propagate the dataCommons parameter, and adds/updates tests to verify correct behavior with and without dataCommons.