### PR TITLE
Make GPAName and dbGaPID optional parameters

### DIFF
--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -1003,14 +1003,14 @@ type Mutation {
         acronym: String, #acronym of the study, optional
         controlledAccess: Boolean!,
         openAccess: Boolean, #optional 
-        dbGaPID: String, # required only Controlled
+        dbGaPID: String, # optional 
         ORCID: String, #optional in format of 0000-1234-2345-3456
         PI: String #optional
         primaryContactID: String #data concierge user ID
         useProgramPC: Boolean!,
         pendingModelChange: Boolean
         isPendingGPA: Boolean
-        GPAName: String
+        GPAName: String # optional 
     ): ApprovedStudy
 
     updateApprovedStudy(
@@ -1019,14 +1019,14 @@ type Mutation {
         acronym: String, #acronym of the study, optional
         controlledAccess: Boolean!,
         openAccess: Boolean, #optional 
-        dbGaPID: String, # required only Controlled
+        dbGaPID: String, # optional 
         ORCID: String, #optional in format of 0000-1234-2345-3456
         PI: String #optional 
         primaryContactID: String, #data concierge user ID
         useProgramPC: Boolean!,
         pendingModelChange: Boolean
         isPendingGPA: Boolean
-        GPAName: String
+        GPAName: String # optional 
     ): ApprovedStudy
 
     requestAccess(

--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -342,13 +342,10 @@ class ApprovedStudiesService {
     }
 
     _setPendingGPA (updateStudy, controlledAccess, isPendingGPA, GPAName) {
+        // Validate GPA parameters before setting them
+        this._validatePendingGPA(GPAName, controlledAccess, isPendingGPA);
+
         if (isTrue(updateStudy.controlledAccess)) {
-            // only editing GPAName
-            if (GPAName !== undefined) {
-                if (!isTrue(isPendingGPA) && !GPAName?.trim()) {
-                    throw new Error(ERROR.INVALID_PENDING_GPA + ";GPA name is missing.");
-                }
-            }
             if (isPendingGPA != null) {
                 updateStudy.isPendingGPA = isPendingGPA;
             }
@@ -368,8 +365,9 @@ class ApprovedStudiesService {
             throw new Error(ERROR.INVALID_PENDING_GPA);
         }
 
-        if (isTrue(controlledAccess) && isPendingGPA !== undefined && !isTrue(isPendingGPA) && !GPAName?.trim()) {
-            throw new Error(ERROR.INVALID_PENDING_GPA + ";GPA name is missing.");
+        // If GPAName is null or empty, isPendingGPA must be true
+        if (isTrue(controlledAccess) && (!GPAName || GPAName.trim() === "") && !isTrue(isPendingGPA)) {
+            throw new Error(ERROR.INVALID_PENDING_GPA);
         }
     }
 
@@ -457,10 +455,6 @@ class ApprovedStudiesService {
         // verify name exists and is not an empty string
         if (!params.name) {
             throw new Error(ERROR.MISSING_STUDY_NAME);
-        }
-        // verify that dbGaPID exists if the study is controlledAccess
-        if (!!params.controlledAccess && !params.dbGaPID){
-            throw new Error(ERROR.MISSING_DB_GAP_ID);
         }
         // validate that ORCID if it exists
         if (!!params.ORCID && !this._validateIdentifier(params.ORCID)) {

--- a/test/services/approved-studies.test.js
+++ b/test/services/approved-studies.test.js
@@ -164,6 +164,96 @@ describe('ApprovedStudiesService', () => {
             service._findUserByID = jest.fn().mockResolvedValue({ ...mockPrimaryContact, role: 'SOME_OTHER_ROLE' });
             await expect(service.addApprovedStudyAPI({ ...mockParams }, mockContext)).rejects.toThrow(ERROR.INVALID_PRIMARY_CONTACT_ROLE);
         });
+
+        it('should successfully create a controlled access study without dbGaPID', async () => {
+            const paramsWithoutDbGaPID = {
+                ...mockParams,
+                controlledAccess: true,
+                dbGaPID: undefined
+            };
+            const result = await service.addApprovedStudyAPI(paramsWithoutDbGaPID, mockContext);
+            expect(service.storeApprovedStudies).toHaveBeenCalledWith(
+                null, 'New Study', 'NS', undefined, null, true, '0000-0002-1825-0097', 'Dr. New', false, null, false, false, 'contact-id', mockGPA
+            );
+            expect(result).toEqual({ ...mockDisplayStudy, primaryContact: mockDisplayUser });
+        });
+
+        it('should throw error when creating controlled access study without GPAName and isPendingGPA false', async () => {
+            const paramsWithoutGPAName = {
+                ...mockParams,
+                controlledAccess: true,
+                GPAName: undefined,
+                isPendingGPA: false
+            };
+            await expect(service.addApprovedStudyAPI(paramsWithoutGPAName, mockContext)).rejects.toThrow(ERROR.INVALID_PENDING_GPA);
+        });
+
+        it('should throw error when creating controlled access study with both dbGaPID and GPAName missing and isPendingGPA false', async () => {
+            const paramsWithoutBoth = {
+                ...mockParams,
+                controlledAccess: true,
+                dbGaPID: undefined,
+                GPAName: undefined,
+                isPendingGPA: false
+            };
+            await expect(service.addApprovedStudyAPI(paramsWithoutBoth, mockContext)).rejects.toThrow(ERROR.INVALID_PENDING_GPA);
+        });
+
+        it('should successfully create a controlled access study without GPAName when isPendingGPA is true', async () => {
+            const paramsWithoutGPAName = {
+                ...mockParams,
+                controlledAccess: true,
+                GPAName: undefined,
+                isPendingGPA: true
+            };
+            const result = await service.addApprovedStudyAPI(paramsWithoutGPAName, mockContext);
+            expect(service.storeApprovedStudies).toHaveBeenCalledWith(
+                null, 'New Study', 'NS', '1234-5678-9012-345', null, true, '0000-0002-1825-0097', 'Dr. New', false, null, false, false, 'contact-id', { GPAName: undefined, isPendingGPA: true }
+            );
+            expect(result).toEqual({ ...mockDisplayStudy, primaryContact: mockDisplayUser });
+        });
+
+        it('should successfully create a controlled access study with empty GPAName when isPendingGPA is true', async () => {
+            const paramsWithEmptyGPAName = {
+                ...mockParams,
+                controlledAccess: true,
+                GPAName: '',
+                isPendingGPA: true
+            };
+            const result = await service.addApprovedStudyAPI(paramsWithEmptyGPAName, mockContext);
+            expect(service.storeApprovedStudies).toHaveBeenCalledWith(
+                null, 'New Study', 'NS', '1234-5678-9012-345', null, true, '0000-0002-1825-0097', 'Dr. New', false, null, false, false, 'contact-id', { GPAName: '', isPendingGPA: true }
+            );
+            expect(result).toEqual({ ...mockDisplayStudy, primaryContact: mockDisplayUser });
+        });
+
+        it('should successfully create a non-controlled access study without dbGaPID', async () => {
+            const paramsWithoutDbGaPID = {
+                ...mockParams,
+                controlledAccess: false,
+                dbGaPID: undefined,
+                isPendingGPA: false
+            };
+            const result = await service.addApprovedStudyAPI(paramsWithoutDbGaPID, mockContext);
+            expect(service.storeApprovedStudies).toHaveBeenCalledWith(
+                null, 'New Study', 'NS', undefined, null, false, '0000-0002-1825-0097', 'Dr. New', false, null, false, false, 'contact-id', { GPAName: "GPA name", isPendingGPA: false }
+            );
+            expect(result).toEqual({ ...mockDisplayStudy, primaryContact: mockDisplayUser });
+        });
+
+        it('should successfully create a non-controlled access study without GPAName', async () => {
+            const paramsWithoutGPAName = {
+                ...mockParams,
+                controlledAccess: false,
+                GPAName: undefined,
+                isPendingGPA: false
+            };
+            const result = await service.addApprovedStudyAPI(paramsWithoutGPAName, mockContext);
+            expect(service.storeApprovedStudies).toHaveBeenCalledWith(
+                null, 'New Study', 'NS', '1234-5678-9012-345', null, false, '0000-0002-1825-0097', 'Dr. New', false, null, false, false, 'contact-id', { GPAName: undefined, isPendingGPA: false }
+            );
+            expect(result).toEqual({ ...mockDisplayStudy, primaryContact: mockDisplayUser });
+        });
     });
 
     describe('editApprovedStudyAPI', () => {
@@ -283,6 +373,107 @@ describe('ApprovedStudiesService', () => {
         it('should throw error if submission update is not acknowledged', async () => {
             service.submissionDAO.updateMany = jest.fn().mockResolvedValue({ acknowledged: false });
             await expect(service.editApprovedStudyAPI({ ...mockParams }, mockContext)).rejects.toThrow(ERROR.FAILED_PRIMARY_CONTACT_UPDATE);
+        });
+
+        it('should successfully update a controlled access study without dbGaPID', async () => {
+            const paramsWithoutDbGaPID = {
+                ...mockParams,
+                controlledAccess: true,
+                dbGaPID: undefined
+            };
+            const result = await service.editApprovedStudyAPI(paramsWithoutDbGaPID, mockContext);
+            expect(service.approvedStudyDAO.update).toHaveBeenCalled();
+            expect(result).toEqual(mockDisplayStudy);
+        });
+
+        it('should throw error when updating controlled access study without GPAName and isPendingGPA false', async () => {
+            const paramsWithoutGPAName = {
+                ...mockParams,
+                controlledAccess: true,
+                GPAName: undefined,
+                isPendingGPA: false
+            };
+            await expect(service.editApprovedStudyAPI(paramsWithoutGPAName, mockContext)).rejects.toThrow(ERROR.INVALID_PENDING_GPA);
+        });
+
+        it('should throw error when updating controlled access study with both dbGaPID and GPAName missing and isPendingGPA false', async () => {
+            const paramsWithoutBoth = {
+                ...mockParams,
+                controlledAccess: true,
+                dbGaPID: undefined,
+                GPAName: undefined,
+                isPendingGPA: false
+            };
+            await expect(service.editApprovedStudyAPI(paramsWithoutBoth, mockContext)).rejects.toThrow(ERROR.INVALID_PENDING_GPA);
+        });
+
+        it('should successfully update a non-controlled access study without dbGaPID', async () => {
+            const paramsWithoutDbGaPID = {
+                ...mockParams,
+                controlledAccess: false,
+                dbGaPID: undefined,
+                isPendingGPA: false
+            };
+            const result = await service.editApprovedStudyAPI(paramsWithoutDbGaPID, mockContext);
+            expect(service.approvedStudyDAO.update).toHaveBeenCalled();
+            expect(result).toEqual(mockDisplayStudy);
+        });
+
+        it('should successfully update a non-controlled access study without GPAName', async () => {
+            const paramsWithoutGPAName = {
+                ...mockParams,
+                controlledAccess: false,
+                GPAName: undefined,
+                isPendingGPA: false
+            };
+            const result = await service.editApprovedStudyAPI(paramsWithoutGPAName, mockContext);
+            expect(service.approvedStudyDAO.update).toHaveBeenCalled();
+            expect(result).toEqual(mockDisplayStudy);
+        });
+
+        it('should successfully update study when dbGaPID is explicitly set to null', async () => {
+            const paramsWithNullDbGaPID = {
+                ...mockParams,
+                controlledAccess: true,
+                dbGaPID: null
+            };
+            const result = await service.editApprovedStudyAPI(paramsWithNullDbGaPID, mockContext);
+            expect(service.approvedStudyDAO.update).toHaveBeenCalled();
+            expect(result).toEqual(mockDisplayStudy);
+        });
+
+        it('should throw error when updating study with GPAName explicitly set to empty string and isPendingGPA false', async () => {
+            const paramsWithEmptyGPAName = {
+                ...mockParams,
+                controlledAccess: true,
+                GPAName: '',
+                isPendingGPA: false
+            };
+            await expect(service.editApprovedStudyAPI(paramsWithEmptyGPAName, mockContext)).rejects.toThrow(ERROR.INVALID_PENDING_GPA);
+        });
+
+        it('should successfully update controlled access study without GPAName when isPendingGPA is true', async () => {
+            const paramsWithoutGPAName = {
+                ...mockParams,
+                controlledAccess: true,
+                GPAName: undefined,
+                isPendingGPA: true
+            };
+            const result = await service.editApprovedStudyAPI(paramsWithoutGPAName, mockContext);
+            expect(service.approvedStudyDAO.update).toHaveBeenCalled();
+            expect(result).toEqual(mockDisplayStudy);
+        });
+
+        it('should successfully update controlled access study with empty GPAName when isPendingGPA is true', async () => {
+            const paramsWithEmptyGPAName = {
+                ...mockParams,
+                controlledAccess: true,
+                GPAName: '',
+                isPendingGPA: true
+            };
+            const result = await service.editApprovedStudyAPI(paramsWithEmptyGPAName, mockContext);
+            expect(service.approvedStudyDAO.update).toHaveBeenCalled();
+            expect(result).toEqual(mockDisplayStudy);
         });
     });
 
@@ -493,6 +684,157 @@ describe('ApprovedStudiesService', () => {
             );
             expect(result).toBeUndefined();
             consoleSpy.mockRestore();
+        });
+    });
+
+    describe('validation methods', () => {
+        describe('_verifyAndFormatStudyParams', () => {
+            it('should not throw error when dbGaPID is missing for controlled access study', () => {
+                const params = {
+                    name: 'Test Study',
+                    controlledAccess: true,
+                    dbGaPID: undefined
+                };
+                expect(() => service._verifyAndFormatStudyParams(params)).not.toThrow();
+            });
+
+            it('should not throw error when dbGaPID is null for controlled access study', () => {
+                const params = {
+                    name: 'Test Study',
+                    controlledAccess: true,
+                    dbGaPID: null
+                };
+                expect(() => service._verifyAndFormatStudyParams(params)).not.toThrow();
+            });
+
+            it('should not throw error when dbGaPID is empty string for controlled access study', () => {
+                const params = {
+                    name: 'Test Study',
+                    controlledAccess: true,
+                    dbGaPID: ''
+                };
+                expect(() => service._verifyAndFormatStudyParams(params)).not.toThrow();
+            });
+
+            it('should not throw error when dbGaPID is missing for non-controlled access study', () => {
+                const params = {
+                    name: 'Test Study',
+                    controlledAccess: false,
+                    dbGaPID: undefined
+                };
+                expect(() => service._verifyAndFormatStudyParams(params)).not.toThrow();
+            });
+
+            it('should still validate ORCID format when provided', () => {
+                const params = {
+                    name: 'Test Study',
+                    controlledAccess: true,
+                    dbGaPID: undefined,
+                    ORCID: 'invalid-orcid'
+                };
+                expect(() => service._verifyAndFormatStudyParams(params)).toThrow(ERROR.INVALID_ORCID);
+            });
+        });
+
+        describe('_validatePendingGPA', () => {
+            it('should throw error when GPAName is missing for controlled access study with isPendingGPA false', () => {
+                expect(() => service._validatePendingGPA(undefined, true, false)).toThrow(ERROR.INVALID_PENDING_GPA);
+            });
+
+            it('should throw error when GPAName is null for controlled access study with isPendingGPA false', () => {
+                expect(() => service._validatePendingGPA(null, true, false)).toThrow(ERROR.INVALID_PENDING_GPA);
+            });
+
+            it('should throw error when GPAName is empty string for controlled access study with isPendingGPA false', () => {
+                expect(() => service._validatePendingGPA('', true, false)).toThrow(ERROR.INVALID_PENDING_GPA);
+            });
+
+            it('should throw error when GPAName is whitespace-only for controlled access study with isPendingGPA false', () => {
+                expect(() => service._validatePendingGPA('   ', true, false)).toThrow(ERROR.INVALID_PENDING_GPA);
+            });
+
+            it('should not throw error when GPAName is missing for controlled access study with isPendingGPA true', () => {
+                expect(() => service._validatePendingGPA(undefined, true, true)).not.toThrow();
+            });
+
+            it('should not throw error when GPAName is null for controlled access study with isPendingGPA true', () => {
+                expect(() => service._validatePendingGPA(null, true, true)).not.toThrow();
+            });
+
+            it('should not throw error when GPAName is empty string for controlled access study with isPendingGPA true', () => {
+                expect(() => service._validatePendingGPA('', true, true)).not.toThrow();
+            });
+
+            it('should not throw error when GPAName has valid value for controlled access study with isPendingGPA false', () => {
+                expect(() => service._validatePendingGPA('Valid GPA Name', true, false)).not.toThrow();
+            });
+
+            it('should not throw error when GPAName has valid value for controlled access study with isPendingGPA true', () => {
+                expect(() => service._validatePendingGPA('Valid GPA Name', true, true)).not.toThrow();
+            });
+
+            it('should not throw error when GPAName is missing for non-controlled access study', () => {
+                expect(() => service._validatePendingGPA(undefined, false, false)).not.toThrow();
+            });
+
+            it('should still throw error when isPendingGPA is true for non-controlled access study', () => {
+                expect(() => service._validatePendingGPA('GPA Name', false, true)).toThrow(ERROR.INVALID_PENDING_GPA);
+            });
+        });
+
+        describe('_setPendingGPA', () => {
+            let mockUpdateStudy;
+
+            beforeEach(() => {
+                mockUpdateStudy = {
+                    controlledAccess: true,
+                    isPendingGPA: false,
+                    GPAName: 'Old GPA Name'
+                };
+            });
+
+            it('should throw error when GPAName is undefined for controlled access study with isPendingGPA false', () => {
+                expect(() => service._setPendingGPA(mockUpdateStudy, true, false, undefined)).toThrow(ERROR.INVALID_PENDING_GPA);
+            });
+
+            it('should throw error when GPAName is null for controlled access study with isPendingGPA false', () => {
+                expect(() => service._setPendingGPA(mockUpdateStudy, true, false, null)).toThrow(ERROR.INVALID_PENDING_GPA);
+            });
+
+            it('should throw error when GPAName is empty string for controlled access study with isPendingGPA false', () => {
+                expect(() => service._setPendingGPA(mockUpdateStudy, true, false, '')).toThrow(ERROR.INVALID_PENDING_GPA);
+            });
+
+            it('should not throw error when GPAName is undefined for controlled access study with isPendingGPA true', () => {
+                expect(() => service._setPendingGPA(mockUpdateStudy, true, true, undefined)).not.toThrow();
+                expect(mockUpdateStudy.GPAName).toBe('Old GPA Name'); // Should remain unchanged when undefined
+            });
+
+            it('should not throw error when GPAName is null for controlled access study with isPendingGPA true', () => {
+                expect(() => service._setPendingGPA(mockUpdateStudy, true, true, null)).not.toThrow();
+                expect(mockUpdateStudy.GPAName).toBe('');
+            });
+
+            it('should not throw error when GPAName is empty string for controlled access study with isPendingGPA true', () => {
+                expect(() => service._setPendingGPA(mockUpdateStudy, true, true, '')).not.toThrow();
+                expect(mockUpdateStudy.GPAName).toBe('');
+            });
+
+            it('should update GPAName when provided for controlled access study', () => {
+                service._setPendingGPA(mockUpdateStudy, true, false, 'New GPA Name');
+                expect(mockUpdateStudy.GPAName).toBe('New GPA Name');
+            });
+
+            it('should set isPendingGPA to false for non-controlled access study', () => {
+                mockUpdateStudy.controlledAccess = false;
+                service._setPendingGPA(mockUpdateStudy, false, false, 'GPA Name');
+                expect(mockUpdateStudy.isPendingGPA).toBe(false);
+            });
+
+            it('should update isPendingGPA when provided for controlled access study', () => {
+                service._setPendingGPA(mockUpdateStudy, true, true, 'GPA Name');
+                expect(mockUpdateStudy.isPendingGPA).toBe(true);
+            });
         });
     });
 });


### PR DESCRIPTION
Make the GPAName and dbGaPID optional parameters createApprovedStudy and updateApprovedStudy. Return an error if updating or creating a study with an invalid GPAName state. If GPAName is null or empty and controlledAccess is true then isPendingGPA must be true. If this validation fails then an error is returned.