### PR TITLE
CRDCDH-3245 API supports setting the application status

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -18,6 +18,7 @@ const ERROR = {
         EMPTY_APPLICATION: "Application array is empty",
         UNDEFINED_STATUS_APPLICATION: "Application state is undefined",
         INVALID_STATE_APPLICATION: "Application state is invalid",
+        INVALID_STATUS_APPLICATION: "The provided application status is invalid",
         // Batch
         UNDEFINED_BATCH_SUBMISSION_ID: "Batch submission ID is undefined",
         UNDEFINED_BATCH_ID: "Batch ID is undefined",

--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -923,7 +923,7 @@ type Query {
 }
 type Mutation {
     "User initiated operations"
-    saveApplication(application: AppInput!): Application
+    saveApplication(application: AppInput!, status: String!): Application
     submitApplication(_id: ID!): Application
     reopenApplication(_id: ID!): Application
 

--- a/services/application.js
+++ b/services/application.js
@@ -187,6 +187,14 @@ class Application {
         return application;
     }
 
+    /**
+     * Provides API functionality to create or save an application.
+     * 
+     * @note If no ID is provided in the application object, a new application will be created.
+     * @param {{ application: object, status: "New" | "In Progress" }} params The request parameters containing the application input object
+     * @param {object} context The request context containing user information
+     * @returns {Promise<object>} The created or updated application object
+     */
     async saveApplication(params, context) {
         verifySession(context)
             .verifyInitialized()
@@ -205,10 +213,14 @@ class Application {
             throw new Error(ERROR.VERIFY.INVALID_PERMISSION);
         }
 
+        if (!params?.status || ![NEW, IN_PROGRESS].includes(params.status)) {
+            throw new Error(ERROR.VERIFY.INVALID_STATUS_APPLICATION);
+        }
+
         const prevStatus = storedApplication?.status;
-        let application = {...storedApplication, ...inputApplication, status: IN_PROGRESS};
+        let application = {...storedApplication, ...inputApplication, status: params.status };
         // auto upgrade version based on configuration
-        application.version = await this._getApplicationVersionByStatus(IN_PROGRESS);
+        application.version = await this._getApplicationVersionByStatus(application.status);
 
         if (inputApplication?.newInstitutions?.length > 0) {
             await this._validateNewInstitution(inputApplication?.newInstitutions);


### PR DESCRIPTION
### Overview

This PR introduces a `status` parameter on the saveApplication API, which allows the frontend to determine which status the application should be saved as. 

> [!Warning]
> This IS A BREAKING CHANGE for the saveApplication API.

### Change Details (Specifics)

- Add a **required** `status` parameter on the saveApplication API (New, In Progress)
- Add relevant unit testing for the new status parameter and validation of the input
- Remove unnecessary duplication of the global constants within the unit tests

### Related Ticket(s)

CRDCDH-3245 (Task)
CRDCDH-3190 (User Story)