### PR TITLE
3240: Fix creating studies via SR

### DIFF
--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -45,7 +45,11 @@ class ApprovedStudiesService {
     }
 
     async storeApprovedStudies(applicationID, studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess, ORCID, PI, openAccess, useProgramPC, pendingModelChange, primaryContactID, pendingGPA, programID) {
-        const approvedStudies = ApprovedStudies.createApprovedStudies(applicationID, studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess, ORCID, PI, openAccess, useProgramPC, pendingModelChange, primaryContactID, pendingGPA, programID);
+        // Validate programID and fall back to NA program if needed
+        const program = await this._validateProgramID(programID);
+        const validatedProgramID = program?._id;
+
+        const approvedStudies = ApprovedStudies.createApprovedStudies(applicationID, studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess, ORCID, PI, openAccess, useProgramPC, pendingModelChange, primaryContactID, pendingGPA, validatedProgramID);
         const res = await this.approvedStudyDAO.create(approvedStudies);
 
         if (!res) {


### PR DESCRIPTION
The storeApprovedStudies method now validates the provided programID and falls back to the NA program if the ID is missing or invalid. Tests were added to verify fallback behavior, error handling when NA program is not found, and correct usage of valid program IDs.