### PR TITLE
3463: consolidate SRF study search

### DIFF
--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -841,7 +841,6 @@ type Query {
     listApplications(
         programName: String,
         studyName: String,
-        studyAbbreviation: String,
         statuses: [String],
         submitterName: String,
         first: Int = -1,

--- a/services/application.js
+++ b/services/application.js
@@ -494,8 +494,8 @@ class Application {
                     select: { studyName: true, studyAbbreviation: true }
                 });
             } catch (err) {
-                console.error("List applications fetch error: study filter distinct options", err);
-                throw new Error(ERROR.LIST_APPLICATIONS_FETCH_FAILED + " Failed step: fetching study filter distinct options.");
+                console.error("List applications fetch error: gathering distinct study values", err);
+                throw new Error(ERROR.LIST_APPLICATIONS_FETCH_FAILED + " Failed step: gathering distinct study values.");
             }
         }
 

--- a/services/application.js
+++ b/services/application.js
@@ -430,17 +430,22 @@ class Application {
         const programNameCondition = (params.programName != null && params.programName !== this._ALL_FILTER) 
             ? { programName: params.programName } 
             : {};
-        // Study name filter, trim input and escape backslashes
-        const studyNameParam = params.studyName?.trim().length > 0
-            ? { contains: params.studyName.trim().replace(/\\/g, "\\\\"), mode: "insensitive" }
-            : params.studyName;
-        const studyNameCondition = (params.studyName != null && params.studyName !== this._ALL_FILTER) ? { studyName: studyNameParam } : {};
-        // Study abbreviation filter
-        const studyAbbreviationCondition = (params.studyAbbreviation != null && params.studyAbbreviation !== this._ALL_FILTER) 
-            ? { studyAbbreviation: params.studyAbbreviation } 
-            : {};
+        // Study filter: search both studyName and studyAbbreviation (OR), case-insensitive partial match
+        const studySearchTerm = params.studyName?.trim();
+        const hasStudyFilter = studySearchTerm?.length > 0 && params.studyName !== this._ALL_FILTER;
+        let studyCondition = {};
+        if (hasStudyFilter) {
+            const studySearchTermSanitized = studySearchTerm.replace(/\\/g, "\\\\");
+            const containsOption = { contains: studySearchTermSanitized, mode: "insensitive" };
+            studyCondition = {
+                OR: [
+                    { studyName: containsOption },
+                    { studyAbbreviation: containsOption }
+                ]
+            };
+        }
         // Assemble generic filter conditions, if scope is own, add applicantID filter
-        const baseConditions = { ...statusCondition, ...programNameCondition, ...studyNameCondition, ...studyAbbreviationCondition, ...submitterNameCondition };
+        const baseConditions = { ...statusCondition, ...programNameCondition, ...studyCondition, ...submitterNameCondition };
         const genericFilterConditions = userScope.isOwnScope()
             ? { ...baseConditions, applicantID: userInfo?._id }
             : baseConditions;
@@ -481,6 +486,14 @@ class Application {
             throw new Error(ERROR.LIST_APPLICATIONS_FETCH_FAILED + " Failed step: fetching application count.");
         }
 
+        // When study filter uses OR, fetch studyName + studyAbbreviation once and derive both distinct lists in memory
+        let studyFilterDistinctRows = null;
+        if (genericFilterConditions.OR) {
+            studyFilterDistinctRows = await this.applicationDAO.findMany(genericFilterConditions, {
+                select: { studyName: true, studyAbbreviation: true }
+            });
+        }
+
         // Query distinct filter options in parallel (programs, studies, studyAbbreviations, statuses, submitter names)
         const runQuery = async (queryName, fn) => {
             try {
@@ -500,12 +513,20 @@ class Application {
                     return (rows ?? []).map(item => item.programName).filter(Boolean);
                 }),
                 runQuery("studies", async () => {
+                    if (studyFilterDistinctRows !== null) {
+                        const names = (studyFilterDistinctRows ?? []).map(item => item.studyName).filter(Boolean);
+                        return Array.from(new Set(names));
+                    }
                     const filterConditions = { ...genericFilterConditions };
                     delete filterConditions.studyName;
                     const rows = await this.applicationDAO.findMany(filterConditions, { select: { studyName: true }, distinct: ['studyName'] });
                     return (rows ?? []).map(item => item.studyName).filter(Boolean);
                 }),
                 runQuery("study abbreviations", async () => {
+                    if (studyFilterDistinctRows !== null) {
+                        const abbreviations = (studyFilterDistinctRows ?? []).map(item => item.studyAbbreviation).filter(Boolean);
+                        return Array.from(new Set(abbreviations));
+                    }
                     const filterConditions = { ...genericFilterConditions };
                     delete filterConditions.studyAbbreviation;
                     const rows = await this.applicationDAO.findMany(filterConditions, { select: { studyAbbreviation: true }, distinct: ['studyAbbreviation'] });

--- a/services/application.js
+++ b/services/application.js
@@ -488,10 +488,15 @@ class Application {
 
         // When study filter uses OR, fetch studyName + studyAbbreviation once and derive both distinct lists in memory
         let studyFilterDistinctRows = null;
-        if (genericFilterConditions.OR) {
-            studyFilterDistinctRows = await this.applicationDAO.findMany(genericFilterConditions, {
-                select: { studyName: true, studyAbbreviation: true }
-            });
+        if (hasStudyFilter) {
+            try {
+                studyFilterDistinctRows = await this.applicationDAO.findMany(genericFilterConditions, {
+                    select: { studyName: true, studyAbbreviation: true }
+                });
+            } catch (err) {
+                console.error("List applications fetch error: study filter distinct options", err);
+                throw new Error(ERROR.LIST_APPLICATIONS_FETCH_FAILED + " Failed step: fetching study filter distinct options.");
+            }
         }
 
         // Query distinct filter options in parallel (programs, studies, studyAbbreviations, statuses, submitter names)
@@ -528,7 +533,6 @@ class Application {
                         return Array.from(new Set(abbreviations));
                     }
                     const filterConditions = { ...genericFilterConditions };
-                    delete filterConditions.studyAbbreviation;
                     const rows = await this.applicationDAO.findMany(filterConditions, { select: { studyAbbreviation: true }, distinct: ['studyAbbreviation'] });
                     return (rows ?? []).map(item => item.studyAbbreviation).filter(Boolean);
                 }),

--- a/test/services/application.test.js
+++ b/test/services/application.test.js
@@ -604,6 +604,99 @@ describe('Application', () => {
             app.applicationDAO.count = jest.fn().mockResolvedValue(0);
             await expect(app.listApplications({}, context)).rejects.toThrow(ERROR.LIST_APPLICATIONS_FETCH_FAILED);
         });
+
+        describe('studyName filter (searches both studyName and studyAbbreviation)', () => {
+            it('passes OR condition when studyName is provided', async () => {
+                const findManyMock = jest.fn().mockResolvedValue([]);
+                app.applicationDAO.findMany = findManyMock;
+                app.applicationDAO.count = jest.fn().mockResolvedValue(0);
+                await app.listApplications({ studyName: 'UniqueName' }, context);
+                const filter = findManyMock.mock.calls[0][0];
+                expect(filter.OR).toBeDefined();
+                expect(Array.isArray(filter.OR)).toBe(true);
+                expect(filter.OR).toHaveLength(2);
+                expect(filter.OR[0]).toEqual({ studyName: { contains: 'UniqueName', mode: 'insensitive' } });
+                expect(filter.OR[1]).toEqual({ studyAbbreviation: { contains: 'UniqueName', mode: 'insensitive' } });
+            });
+
+            it('returns applications matching study name when studyName filter is used', async () => {
+                const matchingApp = { id: 'app1', studyName: 'Cancer Study', studyAbbreviation: 'CS', status: NEW, applicant: { fullName: 'Alice' } };
+                const findManyMock = jest.fn().mockResolvedValue([matchingApp]);
+                app.applicationDAO.findMany = findManyMock;
+                app.applicationDAO.count = jest.fn().mockResolvedValue(1);
+                const result = await app.listApplications({ studyName: 'Cancer' }, context);
+                expect(result.applications.length).toBe(1);
+                expect(result.applications[0].studyName).toBe('Cancer Study');
+                expect(result.total).toBe(1);
+            });
+
+            it('returns applications matching study abbreviation when studyName filter is used', async () => {
+                const matchingApp = { id: 'app2', studyName: 'Other Study', studyAbbreviation: 'BRF', status: NEW, applicant: { fullName: 'Bob' } };
+                const findManyMock = jest.fn().mockResolvedValue([matchingApp]);
+                app.applicationDAO.findMany = findManyMock;
+                app.applicationDAO.count = jest.fn().mockResolvedValue(1);
+                const result = await app.listApplications({ studyName: 'BRF' }, context);
+                expect(result.applications.length).toBe(1);
+                expect(result.applications[0].studyAbbreviation).toBe('BRF');
+                expect(result.total).toBe(1);
+            });
+
+            it('studyName filter is case-insensitive', async () => {
+                const findManyMock = jest.fn().mockResolvedValue([]);
+                app.applicationDAO.findMany = findManyMock;
+                app.applicationDAO.count = jest.fn().mockResolvedValue(0);
+                await app.listApplications({ studyName: 'aBc' }, context);
+                const filter = findManyMock.mock.calls[0][0];
+                expect(filter.OR[0].studyName).toEqual({ contains: 'aBc', mode: 'insensitive' });
+                expect(filter.OR[1].studyAbbreviation).toEqual({ contains: 'aBc', mode: 'insensitive' });
+            });
+
+            it('does not add study filter when studyName is All', async () => {
+                const findManyMock = jest.fn().mockResolvedValue([]);
+                app.applicationDAO.findMany = findManyMock;
+                app.applicationDAO.count = jest.fn().mockResolvedValue(0);
+                await app.listApplications({ studyName: 'All' }, context);
+                const filter = findManyMock.mock.calls[0][0];
+                expect(filter.OR).toBeUndefined();
+            });
+
+            it('does not add study filter when studyName is empty string', async () => {
+                const findManyMock = jest.fn().mockResolvedValue([]);
+                app.applicationDAO.findMany = findManyMock;
+                app.applicationDAO.count = jest.fn().mockResolvedValue(0);
+                await app.listApplications({ studyName: '' }, context);
+                const filter = findManyMock.mock.calls[0][0];
+                expect(filter.OR).toBeUndefined();
+            });
+
+            it('returns distinct studies and studyAbbreviations when studyName filter is applied', async () => {
+                const apps = [
+                    { id: 'app1', studyName: 'Study One', studyAbbreviation: 'S1', status: NEW, applicant: { fullName: 'A' } },
+                    { id: 'app2', studyName: 'Study One', studyAbbreviation: 'S2', status: NEW, applicant: { fullName: 'B' } }
+                ];
+                const studyDistinctRows = [
+                    { studyName: 'Study One', studyAbbreviation: 'S1' },
+                    { studyName: 'Study One', studyAbbreviation: 'S2' }
+                ];
+                let callIndex = 0;
+                app.applicationDAO.findMany = jest.fn().mockImplementation((filter, options) => {
+                    callIndex++;
+                    if (callIndex === 1) return Promise.resolve(apps);
+                    if (callIndex === 2) {
+                        expect(filter.OR).toBeDefined();
+                        expect(options?.select?.studyName).toBe(true);
+                        expect(options?.select?.studyAbbreviation).toBe(true);
+                        return Promise.resolve(studyDistinctRows);
+                    }
+                    return Promise.resolve([]);
+                });
+                app.applicationDAO.count = jest.fn().mockResolvedValue(2);
+                const result = await app.listApplications({ studyName: 'Study' }, context);
+                expect(result.studies).toEqual(['Study One']);
+                expect(result.studyAbbreviations).toEqual(expect.arrayContaining(['S1', 'S2']));
+                expect(result.studyAbbreviations).toHaveLength(2);
+            });
+        });
     });
 
     describe('_getUserScope', () => {


### PR DESCRIPTION
- update the listApplications API to use a single field to search both study name and study abbreviation when returning SRFs. This search will be case insensitive and return matches for study name or study abbreviation.
- removed unused studyAbbreviation parameter from listApplications
- updated unit tests accordingly