### PR TITLE
Trim and validate dataCommons input

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -73,7 +73,7 @@ const ERROR = {
     CREATE_SUBMISSION_INVALID_DATA_TYPE: "submission data type is invalid",
     CREATE_SUBMISSION_INVALID_DELETE_INTENTION: "when intention is Delete, only 'Metadata Only' is allowed",
     UPDATE_SUBMISSION_ERROR: "An error occurred while attempting to update the submission in the database",
-    CREATE_SUBMISSION_INVALID_DATA_COMMONS: "Requested data commons $item$ is not supported",
+    INVALID_DATA_COMMONS_NOT_ALLOWED: "The provided dataCommons value $item$ is not allowed. Allowed data commons are: $accepted$.",
     INVALID_DATA_MODEL_NOT_ALLOWED: "The provided model $item$ is not one of the accepted models. Accepted models are: $accepted$.",
     RETRIEVE_PVS_INVALID_MODEL: "The model input must be a non-empty string.",
     RETRIEVE_PVS_INVALID_PROPERTY_NAME: "The propertyNames input must be an array of non-empty strings (each element non-empty after trim).",

--- a/services/submission.js
+++ b/services/submission.js
@@ -205,6 +205,9 @@ class Submission {
     async createSubmission(params, context) {
         verifySession(context)
             .verifyInitialized();
+        if (params?.dataCommons != null) {
+            params.dataCommons = String(params.dataCommons).trim();
+        }
         // Check user permission to create submission
         const userScope = await this._getUserScope(context?.userInfo, USER_PERMISSION_CONSTANTS.DATA_SUBMISSION.CREATE);
         // User has ALL scope - can create submissions for any study
@@ -3272,14 +3275,29 @@ const getUserEmails = (users) => {
 }
 
 function validateCreateSubmissionParams (params, allowedDataCommons, hiddenDataCommons, intention, dataType) {
-    if (!params.name || params?.name?.trim().length === 0 || !params.studyID || !params.dataCommons) {
+    const dataCommons =
+        params.dataCommons === undefined || params.dataCommons === null
+            ? ''
+            : String(params.dataCommons).trim();
+
+    if (!params.name || params?.name?.trim().length === 0 || !params.studyID || !dataCommons) {
         throw new Error(ERROR.CREATE_SUBMISSION_INVALID_PARAMS);
     }
     if (params?.name?.length > CONSTRAINTS.NAME_MAX_LENGTH) {
         throw new Error(replaceErrorString(ERROR.CREATE_SUBMISSION_INVALID_NAME, `${CONSTRAINTS.NAME_MAX_LENGTH}`));
     }
-    if (hiddenDataCommons.has(params.dataCommons) || !allowedDataCommons.has(params.dataCommons)) {
-        throw new Error(replaceErrorString(ERROR.CREATE_SUBMISSION_INVALID_DATA_COMMONS, `'${params.dataCommons}'`));
+    if (hiddenDataCommons.has(dataCommons) || !allowedDataCommons.has(dataCommons)) {
+        const visibleAllowed = [...allowedDataCommons]
+            .filter((dc) => !hiddenDataCommons.has(dc))
+            .sort();
+        const acceptedDisplay = visibleAllowed.length ? visibleAllowed.join(", ") : "(none available)";
+        throw new Error(
+            replaceErrorString(
+                replaceErrorString(ERROR.INVALID_DATA_COMMONS_NOT_ALLOWED, `'${dataCommons}'`),
+                acceptedDisplay,
+                /\$accepted\$/g
+            )
+        );
     }
     if (!intention) {
         throw new Error(ERROR.CREATE_SUBMISSION_INVALID_INTENTION);
@@ -3290,6 +3308,7 @@ function validateCreateSubmissionParams (params, allowedDataCommons, hiddenDataC
     if (intention === INTENTION.DELETE && dataType !== DATA_TYPE.METADATA_ONLY) {
         throw new Error(ERROR.CREATE_SUBMISSION_INVALID_DELETE_INTENTION);
     }
+    params.dataCommons = dataCommons;
 }
 
 class ValidationRecord {

--- a/services/submission.js
+++ b/services/submission.js
@@ -234,7 +234,7 @@ class Submission {
 
         const intention = [INTENTION.UPDATE, INTENTION.DELETE].find((i) => i.toLowerCase() === params?.intention.toLowerCase());
         const dataType = [DATA_TYPE.METADATA_AND_DATA_FILES, DATA_TYPE.METADATA_ONLY].find((i) => i.toLowerCase() === params?.dataType.toLowerCase());
-        validateCreateSubmissionParams(params, this.allowedDataCommons, this.hiddenDataCommons, intention, dataType, context?.userInfo);
+        validateCreateSubmissionParams(params, this.allowedDataCommons, this.hiddenDataCommons, intention, dataType);
         const [approvedStudies, modelVersion, program] = await Promise.all([
             this._findApprovedStudies([params.studyID]),
             (async () => {

--- a/test/services/data-submission.test.js
+++ b/test/services/data-submission.test.js
@@ -1004,6 +1004,58 @@ describe("Submission.createSubmission", () => {
         expect(mockSubmissionDAO.create).toHaveBeenCalled();
     });
 
+    it("should trim dataCommons whitespace and pass allowed-data-commons validation for ALL scope", async () => {
+        submissionService._getUserScope.mockResolvedValueOnce({
+            isNoneScope: () => false,
+            isAllScope: () => true,
+            isOwnScope: () => false,
+            isStudyScope: () => false,
+            isDCScope: () => false
+        });
+
+        const paramsWithPaddedDc = { ...mockParams, dataCommons: "  commonsA  " };
+        await submissionService.createSubmission(paramsWithPaddedDc, mockContext);
+
+        expect(mockSubmissionDAO.create).toHaveBeenCalledWith(
+            expect.objectContaining({ dataCommons: "commonsA" })
+        );
+    });
+
+    it("should reject whitespace-only dataCommons with invalid params error (ALL scope)", async () => {
+        submissionService._getUserScope.mockResolvedValueOnce({
+            isNoneScope: () => false,
+            isAllScope: () => true,
+            isOwnScope: () => false,
+            isStudyScope: () => false,
+            isDCScope: () => false
+        });
+
+        const paramsWhitespaceOnly = { ...mockParams, dataCommons: "   \t  " };
+        await expect(submissionService.createSubmission(paramsWhitespaceOnly, mockContext))
+            .rejects
+            .toThrow(ERROR.CREATE_SUBMISSION_INVALID_PARAMS);
+    });
+
+    it("should use trimmed dataCommons in not-allowed error message (ALL scope)", async () => {
+        submissionService._getUserScope.mockResolvedValueOnce({
+            isNoneScope: () => false,
+            isAllScope: () => true,
+            isOwnScope: () => false,
+            isStudyScope: () => false,
+            isDCScope: () => false
+        });
+
+        const paramsUnknownPadded = { ...mockParams, dataCommons: "  notInList  " };
+        const expectedMessage = replaceErrorString(
+            replaceErrorString(ERROR.INVALID_DATA_COMMONS_NOT_ALLOWED, `'notInList'`),
+            "commonsA",
+            /\$accepted\$/g
+        );
+        await expect(submissionService.createSubmission(paramsUnknownPadded, mockContext))
+            .rejects
+            .toThrow(expectedMessage);
+    });
+
     it("should allow submission creation for user with OWN scope and assigned study", async () => {
         submissionService._getUserScope.mockResolvedValueOnce({
             isNoneScope: () => false,
@@ -1087,6 +1139,26 @@ describe("Submission.createSubmission", () => {
         const result = await submissionService.createSubmission(mockParams, mockContext);
         expect(result).toBeDefined();
         expect(mockSubmissionDAO.create).toHaveBeenCalled();
+    });
+
+    it("should trim dataCommons for DC scope access check and persist trimmed value", async () => {
+        submissionService._getUserScope.mockResolvedValueOnce({
+            isNoneScope: () => false,
+            isAllScope: () => false,
+            isOwnScope: () => false,
+            isStudyScope: () => false,
+            isDCScope: () => true
+        });
+
+        mockContext.userInfo.dataCommons = ["commonsA"];
+
+        const paramsWithPaddedDc = { ...mockParams, dataCommons: "  commonsA  " };
+        const result = await submissionService.createSubmission(paramsWithPaddedDc, mockContext);
+
+        expect(result).toBeDefined();
+        expect(mockSubmissionDAO.create).toHaveBeenCalledWith(
+            expect.objectContaining({ dataCommons: "commonsA" })
+        );
     });
 
     it("should throw error for user with DC scope but no matching data commons", async () => {


### PR DESCRIPTION
Normalize and validate the dataCommons parameter: trim whitespace early in createSubmission and in validation, reject empty/whitespace-only values, and persist the trimmed value on params. Rename and update the error constant to provide a clearer message with an $accepted$ placeholder, and enhance validation to produce a helpful not-allowed error that lists visible allowed data commons. Added unit tests to cover trimming, whitespace-only rejection, error message formatting, and DC-scope access checks.