### PR TITLE
Make retrievePVsByPropertyName public

### DIFF
--- a/dao/propertyPV.js
+++ b/dao/propertyPV.js
@@ -1,9 +1,6 @@
-const GenericDAO = require("./generic");
-const { MODEL_NAME } = require("../constants/db-constants");
-
-class PropertyPVDAO extends GenericDAO {
-    constructor() {
-        super(MODEL_NAME.PROPERTY_PVS);
+class PropertyPVDAO {
+    constructor(collection) {
+        this.collection = collection;
     }
 
     /**
@@ -16,11 +13,24 @@ class PropertyPVDAO extends GenericDAO {
         if (!propertyNames.length) {
             return [];
         }
-        return await this.findMany({
-            property: { $in: propertyNames },
-            version,
-            model,
-        });
+        return await this.collection.aggregate([
+            {
+                $match: {
+                    property: { $in: propertyNames },
+                    version,
+                    model
+                }
+            },
+            {
+                $project: {
+                    id: '$_id',
+                    property: '$property',
+                    model: '$model',
+                    version: '$version',
+                    permissibleValues: '$PermissibleValues',
+                }
+            }
+        ]);
     }
 }
 

--- a/dao/propertyPV.js
+++ b/dao/propertyPV.js
@@ -28,6 +28,8 @@ class PropertyPVDAO {
                     model: '$model',
                     version: '$version',
                     permissibleValues: '$PermissibleValues',
+                    createdAt: '$createdAt',
+                    updatedAt: '$updatedAt',
                 }
             }
         ]);

--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -1073,7 +1073,7 @@ type Query {
         propertyNames: [String!]!,
         model: String!, # GC, CTDC, ICDC, PSDC
         version: String!
-    ) : [propertyPVs]
+    ) : [propertyPVs] @public
 }
 type Mutation {
     "User initiated operations"

--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -51,6 +51,7 @@ const {replaceErrorString} = require("../utility/string-util");
 const {ADMIN} = require("../crdc-datahub-database-drivers/constants/user-permission-constants");
 const {Release} = require("../services/release-service");
 const DataModelService = require("../services/data-model-service");
+const { MODEL_NAME } = require("../constants/db-constants");
 const PropertyPVDAO = require("../dao/propertyPV");
 const { PropertyPVService } = require("../services/property-pv-service");
 
@@ -77,7 +78,8 @@ dbConnector.connect().then(async () => {
 
     const logCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, LOG_COLLECTION);
     const configurationService = new ConfigurationService();
-    const propertyPVDAO = new PropertyPVDAO();
+    const propertyPVCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, MODEL_NAME.PROPERTY_PVS);
+    const propertyPVDAO = new PropertyPVDAO(propertyPVCollection);
     const propertyPVService = new PropertyPVService(configurationService, propertyPVDAO);
     const authorizationService = new AuthorizationService(configurationService);
     const organizationCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, ORGANIZATION_COLLECTION);

--- a/services/property-pv-service.js
+++ b/services/property-pv-service.js
@@ -1,4 +1,3 @@
-const { verifySession } = require("../verifier/user-info-verifier");
 const { replaceErrorString } = require("../utility/string-util");
 const ERROR = require("../constants/error-constants");
 
@@ -48,8 +47,7 @@ class PropertyPVService {
         this.propertyPVDAO = propertyPVDAO;
     }
 
-    async retrievePVsByPropertyName(params, context) {
-        verifySession(context).verifyInitialized();
+    async retrievePVsByPropertyName(params) {
         const { propertyNames, model, version } = params;
         const uniqueOrderedNames = normalizePropertyNames(propertyNames);
         if (typeof version !== "string" || !version.trim()) {

--- a/test/dao/dao.propertyPV.test.js
+++ b/test/dao/dao.propertyPV.test.js
@@ -19,6 +19,8 @@ describe('PropertyPVDAO.findByPropertiesVersionAndModel', () => {
                 model: '$model',
                 version: '$version',
                 permissibleValues: '$PermissibleValues',
+                createdAt: '$createdAt',
+                updatedAt: '$  "query": "query retrievePVsByPropertyName($propertyNames: [String!]!, $model: String!, $version: String!) {\n  retrievePVsByPropertyName(\n    propertyNames: $propertyNames,\n    model: $model,\n    version: $version\n  ) {id property model version permissibleValues createdAt updatedAt}\n}",',
             }
         },
     ];

--- a/test/dao/dao.propertyPV.test.js
+++ b/test/dao/dao.propertyPV.test.js
@@ -1,0 +1,119 @@
+const PropertyPVDAO = require('../../dao/propertyPV');
+
+describe('PropertyPVDAO.findByPropertiesVersionAndModel', () => {
+    let dao;
+    let collection;
+
+    const expectedPipeline = (propertyNames, version, model) => [
+        {
+            $match: {
+                property: { $in: propertyNames },
+                version,
+                model,
+            },
+        },
+        {
+            $project: {
+                id: '$_id',
+                property: '$property',
+                model: '$model',
+                version: '$version',
+                permissibleValues: '$PermissibleValues',
+            }
+        },
+    ];
+
+    beforeEach(() => {
+        collection = {
+            aggregate: jest.fn(),
+        };
+        dao = new PropertyPVDAO(collection);
+        jest.clearAllMocks();
+    });
+
+    it('returns [] for empty propertyNames without querying', async () => {
+        const result = await dao.findByPropertiesVersionAndModel([], '1', 'ICDC');
+        expect(result).toEqual([]);
+        expect(collection.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('maps BSON PermissibleValues null to permissibleValues null', async () => {
+        collection.aggregate.mockResolvedValue([
+            {
+                _id: 'id1',
+                property: 'study_id',
+                model: 'ICDC',
+                version: '1.0',
+                PermissibleValues: null,
+                id: 'id1',
+                permissibleValues: null,
+                createdAt: new Date('2020-01-01'),
+                updatedAt: new Date('2020-01-02'),
+            },
+        ]);
+
+        const result = await dao.findByPropertiesVersionAndModel(['study_id'], '1.0', 'ICDC');
+
+        expect(result).toHaveLength(1);
+        expect(result[0].permissibleValues).toBeNull();
+        expect(result[0].property).toBe('study_id');
+        expect(result[0].id).toBe('id1');
+        expect(result[0]._id).toBe('id1');
+        expect(collection.aggregate).toHaveBeenCalledWith(
+            expectedPipeline(['study_id'], '1.0', 'ICDC')
+        );
+    });
+
+    it('preserves empty array PermissibleValues', async () => {
+        collection.aggregate.mockResolvedValue([
+            {
+                _id: 'id1',
+                property: 'p',
+                model: 'ICDC',
+                version: '1',
+                PermissibleValues: [],
+                id: 'id1',
+                permissibleValues: [],
+            },
+        ]);
+
+        const result = await dao.findByPropertiesVersionAndModel(['p'], '1', 'ICDC');
+
+        expect(result[0].permissibleValues).toEqual([]);
+    });
+
+    it('maps missing PermissibleValues key to permissibleValues null', async () => {
+        collection.aggregate.mockResolvedValue([
+            {
+                _id: 'id1',
+                property: 'p',
+                model: 'ICDC',
+                version: '1',
+                id: 'id1',
+                permissibleValues: null,
+            },
+        ]);
+
+        const result = await dao.findByPropertiesVersionAndModel(['p'], '1', 'ICDC');
+
+        expect(result[0].permissibleValues).toBeNull();
+    });
+
+    it('passes through non-null PermissibleValues arrays', async () => {
+        collection.aggregate.mockResolvedValue([
+            {
+                _id: 'id1',
+                property: 'p',
+                model: 'ICDC',
+                version: '1',
+                PermissibleValues: ['a', 'b'],
+                id: 'id1',
+                permissibleValues: ['a', 'b'],
+            },
+        ]);
+
+        const result = await dao.findByPropertiesVersionAndModel(['p'], '1', 'ICDC');
+
+        expect(result[0].permissibleValues).toEqual(['a', 'b']);
+    });
+});

--- a/test/services/property-pv-service.test.js
+++ b/test/services/property-pv-service.test.js
@@ -1,9 +1,3 @@
-jest.mock('../../verifier/user-info-verifier', () => ({
-    verifySession: jest.fn(() => ({
-        verifyInitialized: jest.fn()
-    }))
-}));
-
 const { PropertyPVService } = require('../../services/property-pv-service');
 const ERROR = require('../../constants/error-constants');
 const { replaceErrorString } = require('../../utility/string-util');
@@ -37,6 +31,20 @@ describe('PropertyPVService.retrievePVsByPropertyName', () => {
             )
         );
         expect(propertyPVDAO.findByPropertiesVersionAndModel).not.toHaveBeenCalled();
+    });
+
+    it('does not require an authenticated session', async () => {
+        configurationService.findByType.mockResolvedValue({ key: ['ICDC'] });
+        propertyPVDAO.findByPropertiesVersionAndModel.mockResolvedValue([]);
+
+        await expect(
+            service.retrievePVsByPropertyName(
+                { propertyNames: ['p'], model: 'ICDC', version: '1' },
+                {}
+            )
+        ).resolves.toEqual([]);
+
+        expect(propertyPVDAO.findByPropertiesVersionAndModel).toHaveBeenCalled();
     });
 
     it('queries with exact model string passed in', async () => {


### PR DESCRIPTION
- Make retrievePVsByPropertyName public
- remove the prisma layer from the retrievePVsByPropertyName to avoid null permissibleValues values from being converted to empty arrays