### PR TITLE
CRDCDH-3645 Fix `saveApplication` ignores `status` for new applications

### DIFF
--- a/services/application.js
+++ b/services/application.js
@@ -165,19 +165,25 @@ class Application {
         return application || null;
     }
 
-    async createApplication(application, userInfo) {
+    async createApplication(application, userInfo, status = NEW) {
         const timestamp = getCurrentTime();
+
+        const history = [HistoryEventBuilder.createEvent(userInfo._id, NEW, null)];
+        if (status === IN_PROGRESS) {
+            history.push(HistoryEventBuilder.createEvent(userInfo._id, IN_PROGRESS, null));
+        }
+
         let newApplicationProperties = {
             _id: v4(undefined, undefined, undefined),
-            status: NEW,
+            status,
             controlledAccess: application?.controlledAccess,
             applicantID: userInfo._id,
-            history: [HistoryEventBuilder.createEvent(userInfo._id, NEW, null)],
+            history,
             createdAt: timestamp,
             updatedAt: timestamp,
             programAbbreviation: application?.programAbbreviation,
             programDescription: application?.programDescription,
-            version: (application?.version)? application.version : await this._getApplicationVersionByStatus(NEW),
+            version: (application?.version)? application.version : await this._getApplicationVersionByStatus(status),
             inactiveReminder: false, // If deleted, it will set true
             inactiveReminder_7: false,
             inactiveReminder_15: false,
@@ -219,7 +225,11 @@ class Application {
             if (userScope.isNoneScope()) {
                 throw new Error(ERROR.VERIFY.INVALID_PERMISSION);
             }
-            return await this.createApplication(inputApplication, context.userInfo);
+            const requestedStatus = params?.status || NEW;
+            if (![NEW, IN_PROGRESS].includes(requestedStatus)) {
+                throw new Error(ERROR.VERIFY.INVALID_STATE_APPLICATION);
+            }
+            return await this.createApplication(inputApplication, context.userInfo, requestedStatus);
         }
 
         const storedApplication = await this.getApplicationById(id);

--- a/services/application.js
+++ b/services/application.js
@@ -225,7 +225,7 @@ class Application {
             if (userScope.isNoneScope()) {
                 throw new Error(ERROR.VERIFY.INVALID_PERMISSION);
             }
-            const requestedStatus = params?.status || NEW;
+            const requestedStatus = params?.status ?? NEW;
             if (![NEW, IN_PROGRESS].includes(requestedStatus)) {
                 throw new Error(ERROR.VERIFY.INVALID_STATE_APPLICATION);
             }

--- a/test/services/application.test.js
+++ b/test/services/application.test.js
@@ -288,15 +288,62 @@ describe('Application', () => {
             expect(app.applicationDAO.insert).toHaveBeenCalled();
             expect(mockLogCollection.insert).toHaveBeenCalled();
         });
+
+        it('defaults to New when no status is requested for new applications', async () => {
+            app.applicationDAO = {
+                insert: jest.fn().mockResolvedValue({ acknowledged: true }),
+            };
+            mockLogCollection.insert.mockResolvedValue();
+            mockConfigurationService.findByType.mockResolvedValue({ current: '2.0', new: '3.0' });
+
+            const application = { controlledAccess: true };
+            const userInfo = context.userInfo;
+
+            const result = await app.createApplication(application, userInfo);
+
+            expect(result.status).toBe(NEW);
+            expect(result.history).toHaveLength(1);
+            expect(result.history[0]).toMatchObject({ userID: userInfo._id, status: NEW });
+            expect(app.applicationDAO.insert).toHaveBeenCalledWith(expect.objectContaining({ status: NEW }));
+        });
+
+        it('adds a New event before In Progress when requested', async () => {
+            app.applicationDAO = {
+                insert: jest.fn().mockResolvedValue({ acknowledged: true }),
+            };
+            mockLogCollection.insert.mockResolvedValue();
+            mockConfigurationService.findByType.mockResolvedValue({ current: '2.0', new: '3.0' });
+
+            const application = { controlledAccess: true };
+            const userInfo = context.userInfo;
+
+            const result = await app.createApplication(application, userInfo, IN_PROGRESS);
+
+            expect(result.status).toBe(IN_PROGRESS);
+            expect(result.history).toHaveLength(2);
+            expect(result.history[0]).toMatchObject({ userID: userInfo._id, status: NEW });
+            expect(result.history[1]).toMatchObject({ userID: userInfo._id, status: IN_PROGRESS });
+            expect(app.applicationDAO.insert).toHaveBeenCalledWith(expect.objectContaining({ status: IN_PROGRESS }));
+        });
     });
 
     describe('saveApplication', () => {
-        it('creates new application if no id', async () => {
+        it('creates new application with New status if no status is provided', async () => {
             userScopeMock.isNoneScope.mockReturnValue(false);
             userScopeMock.isAllScope.mockReturnValue(true);
             const params = { application: {} };
             jest.spyOn(app, 'createApplication').mockResolvedValue({ _id: 'app2' });
             await expect(app.saveApplication(params, context)).resolves.toEqual({ _id: 'app2' });
+            expect(app.createApplication).toHaveBeenCalledWith({}, context.userInfo, NEW);
+        });
+
+        it('creates new application with In Progress status when requested', async () => {
+            userScopeMock.isNoneScope.mockReturnValue(false);
+            userScopeMock.isAllScope.mockReturnValue(true);
+            const params = { application: {}, status: IN_PROGRESS };
+            jest.spyOn(app, 'createApplication').mockResolvedValue({ _id: 'app2' });
+            await expect(app.saveApplication(params, context)).resolves.toEqual({ _id: 'app2' });
+            expect(app.createApplication).toHaveBeenCalledWith({}, context.userInfo, IN_PROGRESS);
         });
 
         it("should throw an error when the application does not exist", async () => {


### PR DESCRIPTION
### Overview

This PR fixes the `saveApplication` API ignoring the `status` parameter for a new application (i.e. no ID is provided).

### Change Details (Specifics)

- If creating a new application via saveApplication, pass the requested `status` param to the `createApplication` function
- When creating a new application with a `In Progress` status, we insert the `New` event with it
- Update test coverage to reflect these changes

### Related Ticket(s)

CRDCDH-3645 (Task)
CRDCDH-3588 (US)