### PR TITLE
3639: pendingImageDeIdentification in update API

### DIFF
--- a/constants/error-constants.js
+++ b/constants/error-constants.js
@@ -189,6 +189,7 @@ const ERROR = {
     FAILED_APPROVED_STUDY_UPDATE: "Failed to update the approved study.",
     FAILED_PRIMARY_CONTACT_UPDATE: "Failed to update the data concierge in the approved study.",
     INVALID_PENDING_GPA: "Invalid pending GPA is requested.",
+    INVALID_PENDING_IMAGE_DE_IDENTIFICATION: "pendingImageDeIdentification must be a boolean.",
     FAILED_TO_NOTIFY_CLEAR_PENDING_STATE: "Failed to send notification for clearing the approved study; $item$",
     APPROVED_STUDY_NOT_FOUND: "Approved study not found.",
     OMB_NOT_FOUND: "OMB information not found.",

--- a/resources/graphql/crdc-datahub.graphql
+++ b/resources/graphql/crdc-datahub.graphql
@@ -1180,6 +1180,7 @@ type Mutation {
         isPendingGPA: Boolean
         GPAName: String # optional 
         programID: ID # optional
+        pendingImageDeIdentification: Boolean #optional
     ): idType
 
     requestAccess(

--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -250,6 +250,7 @@ class ApprovedStudiesService {
             primaryContactID,
             useProgramPC,
             pendingModelChange,
+            pendingImageDeIdentification,
             isPendingGPA,
             GPAName,
             programID
@@ -310,6 +311,9 @@ class ApprovedStudiesService {
         const currPendingModelChange = updateStudy.pendingModelChange;
         if (pendingModelChange !== undefined) {
             updateStudy.pendingModelChange = isTrue(pendingModelChange);
+        }
+        if (pendingImageDeIdentification !== undefined) {
+            updateStudy.pendingImageDeIdentification = pendingImageDeIdentification;
         }
         updateStudy.programID = program?._id ?? null;
         if (isTrue(updateStudy.controlledAccess)) {
@@ -506,6 +510,9 @@ class ApprovedStudiesService {
         // validate that ORCID if it exists
         if (!!params.ORCID && !this._validateIdentifier(params.ORCID)) {
             throw new Error(ERROR.INVALID_ORCID);
+        }
+        if (params.pendingImageDeIdentification !== undefined && typeof params.pendingImageDeIdentification !== 'boolean') {
+            throw new Error(ERROR.INVALID_PENDING_IMAGE_DE_IDENTIFICATION);
         }
         return params;
     }

--- a/test/services/approved-studies.test.js
+++ b/test/services/approved-studies.test.js
@@ -362,6 +362,39 @@ describe('ApprovedStudiesService', () => {
             expect(result).toEqual(mockDisplayStudy);
         });
 
+        it('should set pendingImageDeIdentification on update when provided as true', async () => {
+            await service.editApprovedStudyAPI({ ...mockParams, pendingImageDeIdentification: true }, mockContext);
+            const updatePayload = service.approvedStudyDAO.update.mock.calls[0][1];
+            expect(updatePayload.pendingImageDeIdentification).toBe(true);
+        });
+
+        it('should set pendingImageDeIdentification on update when provided as false', async () => {
+            await service.editApprovedStudyAPI({ ...mockParams, pendingImageDeIdentification: false }, mockContext);
+            const updatePayload = service.approvedStudyDAO.update.mock.calls[0][1];
+            expect(updatePayload.pendingImageDeIdentification).toBe(false);
+        });
+
+        it('should throw when pendingImageDeIdentification is null', async () => {
+            await expect(
+                service.editApprovedStudyAPI({ ...mockParams, pendingImageDeIdentification: null }, mockContext)
+            ).rejects.toThrow(ERROR.INVALID_PENDING_IMAGE_DE_IDENTIFICATION);
+            expect(service.approvedStudyDAO.update).not.toHaveBeenCalled();
+        });
+
+        it('should throw when pendingImageDeIdentification is a string', async () => {
+            await expect(
+                service.editApprovedStudyAPI({ ...mockParams, pendingImageDeIdentification: 'true' }, mockContext)
+            ).rejects.toThrow(ERROR.INVALID_PENDING_IMAGE_DE_IDENTIFICATION);
+            expect(service.approvedStudyDAO.update).not.toHaveBeenCalled();
+        });
+
+        it('should throw when pendingImageDeIdentification is a number', async () => {
+            await expect(
+                service.editApprovedStudyAPI({ ...mockParams, pendingImageDeIdentification: 1 }, mockContext)
+            ).rejects.toThrow(ERROR.INVALID_PENDING_IMAGE_DE_IDENTIFICATION);
+            expect(service.approvedStudyDAO.update).not.toHaveBeenCalled();
+        });
+
         it('should throw when updating study to an inactive program', async () => {
             const inactiveProgram = { _id: 'inactive-pid', name: 'Inactive', status: ORGANIZATION.STATUSES.INACTIVE };
             service.organizationService.getOrganizationByID = jest.fn().mockResolvedValue(inactiveProgram);


### PR DESCRIPTION
- updated the updateApprovedStudy API to accept a new optional parameter for pendingImageDeIdentification. This parameter will be used to set or remove the condition in the study