### PR TITLE
CRDCDH-3645 fix: Both `New` and `In Progress` events sharing the same timestamp

### DIFF
--- a/domain/history-event.js
+++ b/domain/history-event.js
@@ -1,22 +1,53 @@
 const {getCurrentTime} = require("../crdc-datahub-database-drivers/utility/time-utility");
+
+/**
+ * Builds immutable history-event objects used for application/submission state timelines.
+ */
 class HistoryEventBuilder {
-    constructor(userID, status, comment) {
+    /**
+     * HistoryEventBuilder constructor.
+     * 
+     * @param {string|null|undefined} userID User responsible for the state transition.
+     * @param {string|null|undefined} status State value to record on the event.
+     * @param {string|null|undefined} comment Optional review comment.
+     * @param {Date|undefined} dateTime Optional explicit event timestamp.
+     */
+    constructor(userID, status, comment, dateTime) {
         this._userID = userID;
         this._status = status;
         this._comment = comment;
+        this._dateTime = dateTime;
     }
 
-    static createEvent(userID, status, comment) {
-        return new HistoryEventBuilder(userID, status, comment)
+    /**
+     * Convenience factory for building a history-event payload.
+     *
+     * @param {string|null|undefined} userID User responsible for the state transition.
+     * @param {string|null|undefined} status State value to record on the event.
+     * @param {string|null|undefined} comment Optional review comment.
+     * @param {Date|undefined} dateTime Optional explicit event timestamp.
+     * @returns {{status?: string, reviewComment?: string, userID?: string, dateTime: Date}}
+     */
+    static createEvent(userID, status, comment, dateTime = undefined) {
+        return new HistoryEventBuilder(userID, status, comment, dateTime)
             .build();
     }
 
+    /**
+     * Creates the serialized history-event object.
+     *
+     * @returns {{status?: string, reviewComment?: string, userID?: string, dateTime: Date}}
+     */
     build() {
         let event = {};
         if (this._status) event.status = this._status;
         if (this._comment) event.reviewComment = this._comment;
         if (this._userID != null) event.userID = this._userID;
-        event.dateTime = getCurrentTime();
+        if (this._dateTime instanceof Date) {
+            event.dateTime = this._dateTime
+        } else {
+            event.dateTime = getCurrentTime();
+        }
         return event;
     }
 }

--- a/services/application.js
+++ b/services/application.js
@@ -170,7 +170,7 @@ class Application {
 
         const history = [HistoryEventBuilder.createEvent(userInfo._id, NEW, null)];
         if (status === IN_PROGRESS) {
-            history.push(HistoryEventBuilder.createEvent(userInfo._id, IN_PROGRESS, null));
+            history.push(HistoryEventBuilder.createEvent(userInfo._id, IN_PROGRESS, null, new Date(timestamp.getTime() + 1000)));
         }
 
         let newApplicationProperties = {

--- a/services/application.js
+++ b/services/application.js
@@ -168,10 +168,10 @@ class Application {
     async createApplication(application, userInfo, status = NEW) {
         const timestamp = getCurrentTime();
 
-        const history = [HistoryEventBuilder.createEvent(userInfo._id, NEW, null)];
+        const history = [HistoryEventBuilder.createEvent(userInfo._id, NEW, null, timestamp)];
         if (status === IN_PROGRESS) {
             // Add an additional 1s to the timestamp to ensure the events can be correctly sorted
-            const eventTime = new Date(history[0].dateTime.getTime() + 1000);
+            const eventTime = new Date(timestamp.getTime() + 1000);
             history.push(HistoryEventBuilder.createEvent(userInfo._id, IN_PROGRESS, null, eventTime));
         }
 

--- a/services/application.js
+++ b/services/application.js
@@ -170,7 +170,9 @@ class Application {
 
         const history = [HistoryEventBuilder.createEvent(userInfo._id, NEW, null)];
         if (status === IN_PROGRESS) {
-            history.push(HistoryEventBuilder.createEvent(userInfo._id, IN_PROGRESS, null, new Date(timestamp.getTime() + 1000)));
+            // Add an additional 1s to the timestamp to ensure the events can be correctly sorted
+            const eventTime = new Date(history[0].dateTime.getTime() + 1000);
+            history.push(HistoryEventBuilder.createEvent(userInfo._id, IN_PROGRESS, null, eventTime));
         }
 
         let newApplicationProperties = {

--- a/test/domain/history-event.test.js
+++ b/test/domain/history-event.test.js
@@ -1,0 +1,65 @@
+jest.mock('../../crdc-datahub-database-drivers/utility/time-utility', () => ({
+  getCurrentTime: jest.fn(),
+}));
+
+const { getCurrentTime } = require('../../crdc-datahub-database-drivers/utility/time-utility');
+const { HistoryEventBuilder } = require('../../domain/history-event');
+
+describe('HistoryEventBuilder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be backward compatible and use current time when dateTime is omitted', () => {
+    const mockedNow = new Date('2026-04-07T12:00:00.000Z');
+    getCurrentTime.mockReturnValue(mockedNow);
+
+    const event = HistoryEventBuilder.createEvent('user-1', 'New', 'hello');
+
+    expect(getCurrentTime).toHaveBeenCalledTimes(1);
+    expect(event).toEqual({
+      userID: 'user-1',
+      status: 'New',
+      reviewComment: 'hello',
+      dateTime: mockedNow,
+    });
+  });
+
+  it.each([null, "xyz", 123, undefined])("should ignore the provided datetime when it's not a Date object (value: %p)", (invalidDate) => {
+    const mockedNow = new Date('2026-04-07T12:00:00.000Z');
+    getCurrentTime.mockReturnValue(mockedNow);
+
+    const event = HistoryEventBuilder.createEvent('user-1', 'New', 'hello', invalidDate);
+
+    expect(getCurrentTime).toHaveBeenCalledTimes(1);
+    expect(event).toEqual({
+      userID: 'user-1',
+      status: 'New',
+      reviewComment: 'hello',
+      dateTime: mockedNow,
+    });
+  });
+
+  it('should use the provided dateTime when it is a Date object', () => {
+    const providedDate = new Date('2026-04-07T12:00:02.000Z');
+
+    const event = HistoryEventBuilder.createEvent('user-2', 'In Review', null, providedDate);
+
+    expect(getCurrentTime).not.toHaveBeenCalled();
+    expect(event).toEqual({
+      userID: 'user-2',
+      status: 'In Review',
+      dateTime: providedDate,
+    });
+  });
+
+  // NOTE: This behavior is very likely undesirable. But I'm leaving it unchanged.
+  it('should preserve existing field validation behavior', () => {
+    const mockedNow = new Date('2026-04-07T12:00:03.000Z');
+    getCurrentTime.mockReturnValue(mockedNow);
+
+    const event = HistoryEventBuilder.createEvent(null, '', '');
+
+    expect(event).toEqual({ dateTime: mockedNow });
+  });
+});

--- a/test/services/application.test.js
+++ b/test/services/application.test.js
@@ -323,6 +323,7 @@ describe('Application', () => {
             expect(result.history).toHaveLength(2);
             expect(result.history[0]).toMatchObject({ userID: userInfo._id, status: NEW });
             expect(result.history[1]).toMatchObject({ userID: userInfo._id, status: IN_PROGRESS });
+            expect(new Date(result.history[0].dateTime).getTime()).toBeLessThan(new Date(result.history[1].dateTime).getTime());
             expect(app.applicationDAO.insert).toHaveBeenCalledWith(expect.objectContaining({ status: IN_PROGRESS }));
         });
     });


### PR DESCRIPTION
### Overview

This PR follows up on #1176 by fixing the fact that both the `New` and `In Progress` events had identical timestamps, which caused the frontend to not know how to sort them in the history popup (i.e. In Progress appeared chronologically first).

### Change Details (Specifics)

- Update the history-event builder to support accepting an optional dateTime argument
- Create unit test coverage for history-event to assert backwards compatibility with the change
- When creating a new application, force the `In Progress` event to a timestamp 1s AFTER the new event time

### Related Ticket(s)

CRDCDH-3645