### PR TITLE
Add conditional approval checks and Prisma lookup

### DIFF
--- a/services/application.js
+++ b/services/application.js
@@ -58,6 +58,14 @@ class Application {
         this._VALID_LIST_APPLICATION_STATUSES = [NEW, IN_PROGRESS, SUBMITTED, IN_REVIEW, APPROVED, INQUIRED, REJECTED, CANCELED, DELETED, this._ALL_FILTER];
     }
 
+    _normalizeApplicationStatus(status) {
+        return String(status ?? "").trim().toLowerCase();
+    }
+
+    _isApprovedApplication(application) {
+        return this._normalizeApplicationStatus(application?.status) === this._normalizeApplicationStatus(APPROVED);
+    }
+
     async getApplication(params, context) {
         verifySession(context)
             .verifyInitialized()
@@ -68,7 +76,7 @@ class Application {
 
         let application = await this.getApplicationById(params._id);
         // add logics to check if conditional approval
-        if (application.status === APPROVED){
+        if (this._isApprovedApplication(application)) {
             await this._checkConditionalApproval(application);
         }
         // populate the version with auto upgrade based on configuration
@@ -85,11 +93,14 @@ class Application {
         return [NEW, IN_PROGRESS, INQUIRED].includes(status) ? newStatusVersion : (!version)? currentVersion : version;
     }
 
-    async _checkConditionalApproval(application) {
-        // 1) controlled study missing dbGaPID
-        const studyArr = await this.approvedStudiesService.findByStudyName(application.studyName);
+    /**
+     * Computes conditional / pendingConditions from the approved study for this application study name.
+     * @returns {{ conditional: boolean, pendingConditions: string[] }}
+     */
+    async _computeConditionalApprovalFields(studyName) {
+        const studyArr = await this.approvedStudiesService.findByStudyName(studyName);
         if (!studyArr || studyArr.length < 1) {
-            return;
+            return { conditional: false, pendingConditions: [] };
         }
         const study = studyArr[0];
         const pendingConditions = [
@@ -98,12 +109,16 @@ class Application {
             ...((isTrue(study?.controlledAccess) && isTrue(study?.isPendingGPA)) ? [ERROR.PENDING_APPROVED_STUDY_NO_GPA_INFO] : []),
             ...(isTrue(study?.pendingImageDeIdentification) ? [ERROR.PENDING_IMAGE_DEIDENTIFICATION_CONDITION] : []),
         ];
+        return {
+            conditional: pendingConditions.length > 0,
+            pendingConditions,
+        };
+    }
 
-        application.conditional = pendingConditions.length > 0;
-
-        if (pendingConditions.length > 0) {
-            application.pendingConditions = pendingConditions;
-        }
+    async _checkConditionalApproval(application) {
+        const { conditional, pendingConditions } = await this._computeConditionalApprovalFields(application.studyName);
+        application.conditional = conditional;
+        application.pendingConditions = pendingConditions;
     }
 
     async getApplicationById(id) {
@@ -322,6 +337,9 @@ class Application {
         }
         // auto upgrade version
         const res = await this.getApplicationById(application._id);
+        if (this._isApprovedApplication(res)) {
+            await this._checkConditionalApproval(res);
+        }
         res.version = await this._getApplicationVersionByStatus(IN_PROGRESS);
         return res;
     }
@@ -573,18 +591,28 @@ class Application {
             throw new Error(ERROR.LIST_APPLICATIONS_FETCH_FAILED + " Please see logs for more information.");
         }
 
-        // Format application list (run _checkConditionalApproval sequentially to avoid DB/read spikes when first = -1 or large)
-        const approvedApps = applications.filter(a => a.status === APPROVED);
-        for (const app of approvedApps) {
-            await this._checkConditionalApproval(app);
-        }
-        applications.forEach((app) => {
-            app.applicant = {
+        // Hydrate conditional approval for Approved rows (sequential study lookups) and map to plain objects
+        // so GraphQL always receives conditional / pendingConditions (Prisma entities may drop ad-hoc properties).
+        const mappedApplications = [];
+        for (const app of applications) {
+            const applicant = {
                 applicantID: app?.applicant ? app?.applicant?.id : "",
                 applicantName: app?.applicant ? app?.applicant?.fullName : "",
                 applicantEmail: app?.applicant ? app?.applicant?.email : "",
             };
-        });
+            if (!this._isApprovedApplication(app)) {
+                mappedApplications.push({ ...app, applicant });
+                continue;
+            }
+            const { conditional, pendingConditions } = await this._computeConditionalApprovalFields(app.studyName);
+            mappedApplications.push({
+                ...app,
+                applicant,
+                conditional,
+                pendingConditions,
+            });
+        }
+        applications = mappedApplications;
 
         // Sort statuses in display order
         const statusOrder = [NEW, IN_PROGRESS, SUBMITTED, IN_REVIEW, INQUIRED, APPROVED, REJECTED, CANCELED, DELETED];
@@ -845,9 +873,12 @@ class Application {
                 UpdateApplicationStateEvent.create(context.userInfo._id, context.userInfo.email, context.userInfo.IDP, application._id, application.status, APPROVED)
             ));
         }
-        return await Promise.all(promises).then(results => {
-            return results[0];
-        })
+        const results = await Promise.all(promises);
+        const applicationResult = updated ? results[0] : null;
+        if (applicationResult?.status === APPROVED) {
+            await this._checkConditionalApproval(applicationResult);
+        }
+        return applicationResult ?? results[0];
     }
 
     async rejectApplication(document, context) {

--- a/services/application.js
+++ b/services/application.js
@@ -95,7 +95,7 @@ class Application {
 
     /**
      * Computes conditional / pendingConditions from the approved study for this application study name.
-     * @returns {{ conditional: boolean, pendingConditions: string[] }}
+     * @returns {Promise<{ conditional: boolean, pendingConditions: string[] }>}
      */
     async _computeConditionalApprovalFields(studyName) {
         const studyArr = await this.approvedStudiesService.findByStudyName(studyName);

--- a/services/application.js
+++ b/services/application.js
@@ -841,6 +841,9 @@ class Application {
             version: application.version,
             history: [...(application.history || []), history]
         });
+        if (!updated) {
+            throw new Error(ERROR.UPDATE_FAILED);
+        }
         const isDbGapMissing = (questionnaire?.accessTypes?.includes("Controlled Access") && !questionnaire?.study?.dbGaPPPHSNumber);
         const isPendingGPA = (questionnaire?.accessTypes?.includes("Controlled Access") && Boolean(!updated?.GPAName?.trim()));
         let promises = [];
@@ -874,11 +877,11 @@ class Application {
             ));
         }
         const results = await Promise.all(promises);
-        const applicationResult = updated ? results[0] : null;
-        if (applicationResult?.status === APPROVED) {
+        const applicationResult = results[0];
+        if (this._isApprovedApplication(applicationResult)) {
             await this._checkConditionalApproval(applicationResult);
         }
-        return applicationResult ?? results[0];
+        return applicationResult;
     }
 
     async rejectApplication(document, context) {

--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -23,6 +23,7 @@ const {UserScope} = require("../domain/user-scope");
 const {replaceErrorString} = require("../utility/string-util");
 const NA_PROGRAM = "NA";
 const NA = "NA";
+const prisma = require("../prisma");
 const {isTrue} = require("../crdc-datahub-database-drivers/utility/string-utility");
 const {ORGANIZATION} = require("../crdc-datahub-database-drivers/constants/organization-constants");
 const ProgramDAO = require("../dao/program");
@@ -61,18 +62,28 @@ class ApprovedStudiesService {
 
     /**
      * List Approved Studies by a studyName API.
+     * Case-insensitive match on studyName (Prisma Mongo `equals` + `mode: insensitive`).
      * @api
      * @param {string} studyName
-     * @returns {Promise<Object[]>} An array of ApprovedStudies
+     * @returns {Promise<Object[]>} At most one approved study (same shape as legacy aggregate: array with `_id`)
      */
-    // note: prisma does not work for insensitive search
     async findByStudyName(studyName) {
-        return await this.approvedStudiesCollection.aggregate([{"$match": {$expr: {
-            $eq: [
-                { $toLower: "$studyName" },
-                studyName?.trim()?.toLowerCase()
-            ]
-        }}}, {"$limit": 1}]);
+        const trimmed = studyName?.trim();
+        if (!trimmed) {
+            return [];
+        }
+        const row = await prisma.approvedStudy.findFirst({
+            where: {
+                studyName: {
+                    equals: trimmed,
+                    mode: "insensitive"
+                }
+            }
+        });
+        if (!row) {
+            return [];
+        }
+        return [{ ...row, _id: row.id }];
     }
 
     /**

--- a/test/services/application.test.js
+++ b/test/services/application.test.js
@@ -186,6 +186,20 @@ describe('Application', () => {
             expect(app._checkConditionalApproval).toHaveBeenCalledWith(expect.objectContaining({ _id: 'app1', status: APPROVED, version: '2.0' }));
             expect(app._getApplicationVersionByStatus).toHaveBeenCalledWith(APPROVED, '2.0');
         });
+
+        it('calls _checkConditionalApproval when status matches Approved case-insensitively', async () => {
+            userScopeMock.isNoneScope.mockReturnValue(false);
+            userScopeMock.isAllScope.mockReturnValue(true);
+            UserScope.create.mockReturnValue(userScopeMock);
+
+            app.getApplicationById = jest.fn().mockResolvedValue({ _id: 'app1', status: 'approved', version: '2.0' });
+            app._checkConditionalApproval = jest.fn().mockResolvedValue(undefined);
+            app._getApplicationVersionByStatus = jest.fn().mockResolvedValue('2.0');
+
+            await app.getApplication({ _id: 'app1' }, context);
+
+            expect(app._checkConditionalApproval).toHaveBeenCalledWith(expect.objectContaining({ _id: 'app1', status: 'approved' }));
+        });
     });
 
     describe('_getApplicationVersionByStatus', () => {
@@ -230,11 +244,12 @@ describe('Application', () => {
             expect(application.pendingConditions).toContain(ERROR.PENDING_IMAGE_DEIDENTIFICATION_CONDITION);
         });
 
-        it('does nothing if no studies found', async () => {
+        it('sets conditional false and empty pendingConditions when no studies found', async () => {
             mockApprovedStudiesService.findByStudyName.mockResolvedValue([]);
             const application = { studyName: 'study1' };
             await app._checkConditionalApproval(application);
-            expect(application.conditional).toBeUndefined();
+            expect(application.conditional).toBe(false);
+            expect(application.pendingConditions).toEqual([]);
         });
     });
 
@@ -416,6 +431,37 @@ describe('Application', () => {
 
             const result = await app.getMyLastApplication({}, context);
             expect(result).toMatchObject({ _id: 'app1', version: '3.0', institution: { id: 'inst1', _id: 'inst1' } });
+        });
+
+        it('hydrates conditional and pendingConditions when approved study has pending image de-identification', async () => {
+            userScopeMock.isNoneScope.mockReturnValue(false);
+            userScopeMock.isAllScope.mockReturnValue(true);
+            UserScope.create.mockReturnValue(userScopeMock);
+            app.applicationDAO = {
+                aggregate: jest.fn().mockResolvedValue([{ _id: 'app1', status: APPROVED }])
+            };
+            mockConfigurationService.findByType.mockResolvedValue({ current: '2.0', new: '3.0' });
+            mockApprovedStudiesService.findByStudyName.mockResolvedValue([{
+                controlledAccess: false,
+                pendingModelChange: false,
+                pendingImageDeIdentification: true
+            }]);
+            jest.spyOn(app, 'getApplicationById').mockResolvedValue({
+                _id: 'app1',
+                status: APPROVED,
+                studyName: 'study1',
+                institution: { id: 'inst1', _id: 'inst1' }
+            });
+
+            const result = await app.getMyLastApplication({}, context);
+
+            expect(result).toMatchObject({
+                _id: 'app1',
+                version: '3.0',
+                conditional: true,
+                institution: { id: 'inst1', _id: 'inst1' }
+            });
+            expect(result.pendingConditions).toContain(ERROR.PENDING_IMAGE_DEIDENTIFICATION_CONDITION);
         });
 
         it('returns null when no previous approved application exists', async () => {
@@ -869,6 +915,50 @@ describe('Application', () => {
                 undefined,
                 mockNewProgram
             );
+        });
+
+        it('returns conditional and pendingConditions on the approved application when the study has pending image de-identification', async () => {
+            const mockApplication = {
+                _id: 'app1',
+                status: IN_REVIEW,
+                studyName: 'study1',
+                programName: 'Existing Program',
+                questionnaireData: JSON.stringify({ program: { _id: 'program1' } })
+            };
+            const mockQuestionnaire = { program: { _id: 'program1' } };
+            const mockExistingProgram = { _id: 'program1', name: 'Existing Program' };
+            const approvedFromDb = {
+                ...mockApplication,
+                status: APPROVED,
+                reviewComment: 'Approved',
+                history: []
+            };
+
+            mockApprovedStudiesService.findByStudyName
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([{
+                    controlledAccess: false,
+                    pendingModelChange: false,
+                    pendingImageDeIdentification: true
+                }]);
+            mockOrganizationService.getOrganizationByID.mockResolvedValue(mockExistingProgram);
+            mockOrganizationService.findOneByProgramName.mockResolvedValue(null);
+            app.getApplicationById = jest.fn()
+                .mockResolvedValueOnce(mockApplication)
+                .mockResolvedValueOnce(approvedFromDb);
+            app.applicationDAO.update = jest.fn().mockImplementation((payload) =>
+                Promise.resolve({ ...mockApplication, ...payload })
+            );
+            app._saveApprovedStudies = jest.fn().mockResolvedValue({ _id: 'study1' });
+            app._findUsersByApplicantIDs = jest.fn().mockResolvedValue([]);
+            mockLogCollection.insert.mockResolvedValue();
+            global.getApplicationQuestionnaire = jest.fn().mockReturnValue(mockQuestionnaire);
+
+            const result = await app.approveApplication({ _id: 'app1', comment: 'Approved' }, context);
+
+            expect(result.status).toBe(APPROVED);
+            expect(result.conditional).toBe(true);
+            expect(result.pendingConditions).toContain(ERROR.PENDING_IMAGE_DEIDENTIFICATION_CONDITION);
         });
 
         it('should use existing program when program exists', async () => {

--- a/test/services/application.test.js
+++ b/test/services/application.test.js
@@ -824,6 +824,26 @@ describe('Application', () => {
                 .rejects.toThrow(/duplicate/i);
         });
 
+        it('throws UPDATE_FAILED when DAO update returns falsy and does not call addNewInstitutions', async () => {
+            const mockApplication = {
+                _id: 'app1',
+                status: IN_REVIEW,
+                studyName: 'study1',
+                questionnaireData: JSON.stringify({ program: { _id: 'program1' } })
+            };
+            app.getApplicationById = jest.fn().mockResolvedValue(mockApplication);
+            mockApprovedStudiesService.findByStudyName.mockResolvedValue([]);
+            mockOrganizationService.getOrganizationByID.mockResolvedValue({ _id: 'program1' });
+            mockOrganizationService.findOneByProgramName.mockResolvedValue(null);
+            app._getApplicationVersionByStatus = jest.fn().mockResolvedValue('1.0');
+            app.applicationDAO.update = jest.fn().mockResolvedValue(null);
+
+            await expect(app.approveApplication({ _id: 'app1', comment: 'Approved' }, context))
+                .rejects.toThrow(ERROR.UPDATE_FAILED);
+
+            expect(mockInstitutionService.addNewInstitutions).not.toHaveBeenCalled();
+        });
+
         it('should create program before creating study when no existing program', async () => {
             const mockApplication = { 
                 _id: 'app1', 


### PR DESCRIPTION
- normalize application status string before checking if approved, not required for this change but best practice for string comparison
- convert findByStudyName to a Prisma call (case insensitive) and add logic to calculate and set "conditional" and "pendingCondition" fields in the graphQL result for approved SRFs