### PR TITLE
CRDCDH-3621 Fix preserving new lines in email templates

### DIFF
--- a/lib/create-email-template.js
+++ b/lib/create-email-template.js
@@ -17,6 +17,15 @@ handlebars.registerHelper('or', function () {
     return Array.from(arguments).slice(0, -1).some(Boolean);
 });
 
+// nlToBr helper: converts newlines to <br> for compatibility
+handlebars.registerHelper('nlToBr', function (text) {
+    if (!text) {
+        return '';
+    }
+    const escaped = handlebars.Utils.escapeExpression(text);
+    return new handlebars.SafeString(escaped.replace(/\n/g, '<br>'));
+});
+
 
 async function createEmailTemplate(templateName, params, basePath = 'resources/email-templates') {
     const templatePath = path.resolve(basePath, templateName);

--- a/resources/email-templates/notification-template-SR-pending-conditions.html
+++ b/resources/email-templates/notification-template-SR-pending-conditions.html
@@ -20,7 +20,7 @@
     <span>[Review Comments]:</span>
   </p>
   <p>
-    <span style="white-space: pre-wrap;">{{ reviewComments }}</span>
+    <span>{{nlToBr reviewComments}}</span>
   </p>
   {{#if pendingConditions}}
   <p>

--- a/resources/email-templates/notification-template-sr-inquire.html
+++ b/resources/email-templates/notification-template-sr-inquire.html
@@ -26,7 +26,7 @@
     {{#if reviewComments}}
     <p>
       <span>[Review Comments]:</span><br>
-      <span style="white-space: pre-wrap;">{{ reviewComments }}</span>
+      <span>{{nlToBr reviewComments}}</span>
     </p>
     {{/if}}
     <p>{{ thirdMessage }}</p>

--- a/resources/email-templates/notification-template.html
+++ b/resources/email-templates/notification-template.html
@@ -17,7 +17,7 @@
     {{#if reviewComments}}
     <p>
       <span>[Review Comments]:</span><br>
-      <span style="white-space: pre-wrap;">{{ reviewComments }}</span>
+      <span>{{nlToBr reviewComments}}</span>
     </p>
     {{/if}}
     {{#if secondMessage}}


### PR DESCRIPTION
### Overview

New lines weren't being preserved in Outlook specifically. Updated to use html line breaks instead for compatability.

### Change Details (Specifics)

- Added handlebars helper for converting new lines to html line break tags
- Updated reviewComments in emails to use new helper

<details>
  <summary>Outlook Email:</summary>

<img width="794" height="694" alt="image" src="https://github.com/user-attachments/assets/a36347c5-235e-40e1-9909-7a865a01cc6a" />
</details>



### Related Ticket(s)

[CRDCDH-3621](https://tracker.nci.nih.gov/browse/CRDCDH-3621) (Task)
[CRDCDH-3594](https://tracker.nci.nih.gov/browse/CRDCDH-3594) (US)