### PR TITLE
When a data file is deleted, reset associated file validation status

### DIFF
--- a/services/data-record-service.js
+++ b/services/data-record-service.js
@@ -450,6 +450,34 @@ class DataRecordService {
         ]}}}]);
     }
 
+    /**
+     * After one or more data files are removed from S3, set s3FileInfo.status to New on matching data records
+     * (top-level data record status is not changed). Updates updatedAt.
+     * @param {string} submissionID
+     * @param {string[]|null} fileNames - Names of removed data files. Pass null to match every data record
+     *        in the submission that has s3FileInfo (e.g. delete all data files with no exclusives).
+     * @returns {Promise<import('mongodb').UpdateResult>}
+     */
+    async resetS3FileLinkedMetadataStatusToNew(submissionID, fileNames) {
+        if (fileNames && fileNames.length === 0) {
+            return { acknowledged: true, modifiedCount: 0, matchedCount: 0 };
+        }
+        const filter = {
+            submissionID,
+            s3FileInfo: { $exists: true, $ne: null }
+        };
+        if (fileNames != null) {
+            filter["s3FileInfo.fileName"] = { $in: fileNames };
+        }
+        return await this.dataRecordsCollection.updateMany(
+            filter,
+            [{ $set: {
+                updatedAt: getCurrentTime(),
+                s3FileInfo: { $mergeObjects: ["$s3FileInfo", { status: VALIDATION_STATUS.NEW }] }
+            }}]
+        );
+    }
+
     _getSubmissionStatQuery(submissionID, validNodeStatus) {
         return [
             {$match:{

--- a/services/submission.js
+++ b/services/submission.js
@@ -1774,6 +1774,8 @@ class Submission {
             let existingFiles;
             let deletedResult;
             let nodeIDsForLogging;
+            /** null = every s3FileInfo-linked record in the submission; string[] = match those file names */
+            let metadataResetFileNames;
             
             if (deleteAll) {
                 // Delete QC results
@@ -1784,12 +1786,14 @@ class Submission {
                     // Delete entire directory
                     deletedResult = await this._deleteDataFiles(new Map(), aSubmission, deleteAll, exclusiveIDs);
                     nodeIDsForLogging = 'deleteAll';
+                    metadataResetFileNames = null;
                 } 
                 else {
                     // get all files and filter out exclusives
                     const allFiles = await this._getAllSubmissionDataFiles(aSubmission?.bucketName, aSubmission?.rootPath) || [];
                     const exclusiveSet = new Set(exclusiveIDs);
                     const filesToDelete = allFiles.filter(fileName => !exclusiveSet.has(fileName));
+                    metadataResetFileNames = filesToDelete;
                     
                     // if no files to delete, throw error
                     if (filesToDelete.length === 0) {
@@ -1824,6 +1828,7 @@ class Submission {
                 // delete data files by nodeIDs
                 deletedResult = await this._deleteDataFiles(existingFiles, aSubmission, false, []);
                 nodeIDsForLogging = deletedResult;
+                metadataResetFileNames = deletedResult;
             }
             
             // if deleted files, update submission data file info
@@ -1856,10 +1861,13 @@ class Submission {
                 
                 // log data record
                 promises.push(this._logDataRecord(context?.userInfo, aSubmission._id, VALIDATION.TYPES.DATA_FILE, nodeIDsForLogging));
+                promises.push(
+                    this.dataRecordService.resetS3FileLinkedMetadataStatusToNew(aSubmission._id, metadataResetFileNames)
+                );
                 
                 // Await all promises to ensure errors are properly caught and handled
-                // Note: qcDeletionResult and logResult are available but not used
-                const [submissionDataFiles, dataFileSize, qcDeletionResult, logResult] = await Promise.all(promises);
+                // Note: qcDeletionResult, logResult, and metadata reset result are available but not used
+                const [submissionDataFiles, dataFileSize, qcDeletionResult, logResult, _metadataReset] = await Promise.all(promises);
                 
                 // reset fileValidationStatus if the number of data files changed. No data files exists if null
                 const fileValidationStatus = submissionDataFiles?.length > 0 ? VALIDATION_STATUS.NEW : null;

--- a/test/services/data-record-service.test.js
+++ b/test/services/data-record-service.test.js
@@ -385,6 +385,51 @@ describe('DataRecordService', () => {
     });
   });
 
+  describe('resetS3FileLinkedMetadataStatusToNew', () => {
+    test('should update by file names and set New only on s3FileInfo', async () => {
+      mockDataRecordsCollection.updateMany.mockResolvedValue({ modifiedCount: 2 });
+
+      const result = await dataRecordService.resetS3FileLinkedMetadataStatusToNew('sub-1', ['a.txt', 'b.txt']);
+
+      expect(result).toEqual({ modifiedCount: 2 });
+        expect(mockDataRecordsCollection.updateMany).toHaveBeenCalledWith(
+        {
+          submissionID: 'sub-1',
+          s3FileInfo: { $exists: true, $ne: null },
+          's3FileInfo.fileName': { $in: ['a.txt', 'b.txt'] }
+        },
+        expect.arrayContaining([
+          expect.objectContaining({
+            $set: expect.objectContaining({
+              s3FileInfo: { $mergeObjects: ['$s3FileInfo', { status: 'New' }] }
+            })
+          })
+        ])
+      );
+    });
+
+    test('should match all s3FileInfo records when fileNames is null', async () => {
+      mockDataRecordsCollection.updateMany.mockResolvedValue({ modifiedCount: 5 });
+
+      await dataRecordService.resetS3FileLinkedMetadataStatusToNew('sub-1', null);
+
+      expect(mockDataRecordsCollection.updateMany).toHaveBeenCalledWith(
+        {
+          submissionID: 'sub-1',
+          s3FileInfo: { $exists: true, $ne: null }
+        },
+        expect.any(Array)
+      );
+    });
+
+    test('should no-op for empty fileNames array', async () => {
+      const result = await dataRecordService.resetS3FileLinkedMetadataStatusToNew('sub-1', []);
+
+      expect(result).toEqual({ acknowledged: true, modifiedCount: 0, matchedCount: 0 });
+      expect(mockDataRecordsCollection.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
   describe('_getSubmissionStatQuery', () => {
     test('should return correct aggregation pipeline', () => {
       const validNodeStatus = ['New', 'Passed', 'Warning', 'Error'];

--- a/test/services/submission.service.test.js
+++ b/test/services/submission.service.test.js
@@ -163,7 +163,8 @@ describe('Submission Service - getSubmission', () => {
         };
 
         mockDataRecordService = {
-            countNodesBySubmissionID: jest.fn()
+            countNodesBySubmissionID: jest.fn(),
+            resetS3FileLinkedMetadataStatusToNew: jest.fn().mockResolvedValue({ modifiedCount: 0, matchedCount: 0 })
         };
 
         mockBatchService = {
@@ -984,6 +985,7 @@ describe('Submission Service - getSubmission', () => {
                 );
                 expect(submissionService._deleteDataFiles).toHaveBeenCalled();
                 expect(result.message).toContain('1 nodes deleted');
+                expect(mockDataRecordService.resetS3FileLinkedMetadataStatusToNew).toHaveBeenCalledWith('sub-123', deletedFiles);
             });
 
             it('should throw error when collaborator has study scope but no study access', async () => {


### PR DESCRIPTION
The issue was when data files are deleted, associated s3FileInfo are still "Pass", and won't be validated again if the scope is "New". 
Solution: reset associated s3FileInfo to "New" when a data file is delete, to force it to be validated in next file validation.