### PR TITLE
CRDCDH-3632 Support shorter deletion windows for "New" SRFs 

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,12 +84,23 @@ app.use("/api/graphql", graphqlRouter);
         const applicationCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, APPLICATION_COLLECTION);
         const userCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, USER_COLLECTION);
         const submissionCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, SUBMISSIONS_COLLECTION);
-        const emailParams = {url: config.emails_url, officialEmail: config.official_email, inactiveDays: config.inactive_application_days, remindDay: config.remind_application_days,
-            submissionSystemPortal: config.submission_system_portal, submissionHelpdesk: config.submission_helpdesk, remindSubmissionDay: config.inactiveSubmissionNotifyDays,
-            techSupportEmail: config.techSupportEmail, conditionalSubmissionContact: config.conditionalSubmissionContact, submissionGuideURL: config.submissionGuideUrl,
-            completedSubmissionDays: config.completed_submission_days, inactiveSubmissionDays: config.inactive_submission_days, finalRemindSubmissionDay: config.inactive_submission_days,
-            inactiveApplicationNotifyDays: config.inactiveApplicationNotifyDays};
-
+        const emailParams = {
+            url: config.emails_url,
+            officialEmail: config.official_email,
+            inactiveDays: config.inactive_application_days,
+            inactiveNewApplicationDays: config.inactive_new_application_days,
+            remindDay: config.remind_application_days,
+            submissionSystemPortal: config.submission_system_portal,
+            submissionHelpdesk: config.submission_helpdesk,
+            remindSubmissionDay: config.inactiveSubmissionNotifyDays,
+            techSupportEmail: config.techSupportEmail,
+            conditionalSubmissionContact: config.conditionalSubmissionContact,
+            submissionGuideURL: config.submissionGuideUrl,
+            completedSubmissionDays: config.completed_submission_days,
+            inactiveSubmissionDays: config.inactive_submission_days,
+            finalRemindSubmissionDay: config.inactive_submission_days,
+            inactiveApplicationNotifyDays: config.inactiveApplicationNotifyDays,
+        };
         
         const logCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, LOG_COLLECTION);
         const approvedStudiesCollection = new MongoDBCollection(dbConnector.client, DATABASE_NAME, APPROVED_STUDIES_COLLECTION);

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ const EMAIL_PASSWORD = "EMAIL_PASSWORD";
 const EMAIL_URL = "EMAIL_URL";
 const OFFICIAL_EMAIL = "OFFICIAL_EMAIL";
 const INACTIVE_APPLICATION_DAYS= "INACTIVE_APPLICATION_DAYS";
+const INACTIVE_NEW_APPLICATION_DAYS = "INACTIVE_NEW_APPLICATION_DAYS";
 const REMIND_APPLICATION_DAYS = "REMIND_APPLICATION_DAYS";
 const SUBMISSION_SYSTEM_PORTAL = "SUBMISSION_SYSTEM_PORTAL";
 const SUBMISSION_HELPDESK = "SUBMISSION_HELPDESK";
@@ -67,6 +68,7 @@ let config = {
         const scheduledJobsConf = await configurationService.findByType(SCHEDULED_JOBS);
         const inactiveUserDaysConf = scheduledJobsConf?.[INACTIVE_USER_DAYS];
         const inactiveApplicationDaysConf = scheduledJobsConf?.[INACTIVE_APPLICATION_DAYS];
+        const inactiveNewApplicationDaysConf = scheduledJobsConf?.[INACTIVE_NEW_APPLICATION_DAYS];
         const remindApplicationDaysConf = scheduledJobsConf?.[REMIND_APPLICATION_DAYS];
         const inactiveSubmissionDaysConf = scheduledJobsConf?.[INACTIVE_SUBMISSION_DAYS_DELETE];
         const completedSubmissionDaysConf = scheduledJobsConf?.[COMPLETED_RETENTION_DAYS];
@@ -121,6 +123,7 @@ let config = {
             inactive_user_days : inactiveUserDaysConf || (process.env.INACTIVE_USER_DAYS || 60),
             remind_application_days: remindApplicationDaysConf || (process.env.REMIND_APPLICATION_DAYS || 165),
             inactive_application_days : inactiveApplicationDaysConf || (process.env.INACTIVE_APPLICATION_DAYS || 180),
+            inactive_new_application_days : inactiveNewApplicationDaysConf || (process.env.INACTIVE_NEW_APPLICATION_DAYS || 30),
             // Email settings
             email_transport: getTransportConfig(emailSmtpHostConf, emailSmtpPortConf, emailSmtpUserConf, emailSmtpPasswordConf),
             emails_enabled: process.env.EMAILS_ENABLED ? process.env.EMAILS_ENABLED.toLowerCase() === 'true' : true,

--- a/documentation/3-6-0/3-6-0-migration.js
+++ b/documentation/3-6-0/3-6-0-migration.js
@@ -180,6 +180,26 @@ async function executeStsResourceConfigMigration(db) {
 }
 
 /**
+ * Execute adding INACTIVE_NEW_APPLICATION_DAYS configuration
+ */
+async function executeShortInactiveApplicationConfigMigration(db) {
+    console.log('🔄 Executing INACTIVE_NEW_APPLICATION_DAYS configuration migration...');
+    try {
+        const migration = require('./add-short-inactive-application-config');
+        const result = await migration.addShortInactiveApplicationConfig(db);
+        if (result.success) {
+            console.log('✅ INACTIVE_NEW_APPLICATION_DAYS migration completed successfully');
+        } else {
+            console.log('❌ INACTIVE_NEW_APPLICATION_DAYS migration failed');
+        }
+        return result;
+    } catch (error) {
+        console.error('❌ Error executing INACTIVE_NEW_APPLICATION_DAYS configuration migration:', error.message);
+        return { success: false, error: error.message };
+    }
+}
+
+/**
  * Execute ApprovedStudy.status backfill (Active where missing)
  */
 async function executeApprovedStudyStatusBackfill(db) {
@@ -323,6 +343,11 @@ async function orchestrateMigration() {
                 name: "Add CHATBOT configuration",
                 file: "add-chatbot-enabled-config.js",
                 execute: () => executeChatbotEnabledConfigMigration(db)
+            },
+            {
+                name: "Add INACTIVE_NEW_APPLICATION_DAYS configuration",
+                file: "add-short-inactive-application-config.js",
+                execute: () => executeShortInactiveApplicationConfigMigration(db)
             },
             {
                 name: "Backfill ApprovedStudy.status (Active where missing)",

--- a/documentation/3-6-0/add-short-inactive-application-config.js
+++ b/documentation/3-6-0/add-short-inactive-application-config.js
@@ -1,0 +1,50 @@
+/**
+ * Migration: Add INACTIVE_NEW_APPLICATION_DAYS configuration entry
+ *
+ * Inserts or updates the SCHEDULED_JOBS configuration document to include the
+ * INACTIVE_NEW_APPLICATION_DAYS key with a default of 30 days if missing.
+ *
+ * Usage: This migration is called by the 3.6.0 migration orchestrator
+ */
+
+const CONFIGURATION_COLLECTION = 'configuration';
+const CONFIG_TYPE = 'SCHEDULED_JOBS';
+const CONFIG_ID = '8e2d00f4-2ac6-4a0d-a453-733cc218b04f';
+const CONFIG_KEY = 'INACTIVE_NEW_APPLICATION_DAYS';
+const DEFAULT_DAYS = 30;
+
+async function addShortInactiveApplicationConfig(db) {
+  console.log('🔄 Adding INACTIVE_NEW_APPLICATION_DAYS configuration...');
+  const configCollection = db.collection(CONFIGURATION_COLLECTION);
+
+  try {
+    // Ensure document exists
+    await configCollection.updateOne(
+      { type: CONFIG_TYPE },
+      { $setOnInsert: { _id: CONFIG_ID, type: CONFIG_TYPE } },
+      { upsert: true }
+    );
+
+    // Set the key if it is missing or null
+    const result = await configCollection.updateOne(
+      { type: CONFIG_TYPE, [CONFIG_KEY]: { $eq: null } },
+      { $set: { [CONFIG_KEY]: DEFAULT_DAYS } }
+    );
+
+    if (result.modifiedCount > 0) {
+      console.log(`   ✅ Added ${CONFIG_KEY} (${DEFAULT_DAYS}) to ${CONFIG_TYPE} configuration`);
+      return { success: true, added: true };
+    }
+
+    console.log(`   ℹ️  ${CONFIG_KEY} already present in ${CONFIG_TYPE}, skipping`);
+    return { success: true, skipped: true };
+
+  } catch (error) {
+    console.error(`   ❌ Error adding ${CONFIG_KEY} configuration:`, error.message);
+    return { success: false, error: error.message };
+  }
+}
+
+module.exports = {
+  addShortInactiveApplicationConfig
+};

--- a/services/application.js
+++ b/services/application.js
@@ -964,8 +964,6 @@ class Application {
 
             const appsMap = new Map();
             (defaultApps || []).forEach(a => appsMap.set(a._id, a));
-
-            const shortIds = new Set((shortApps || []).map(a => a._id));
             (shortApps || []).forEach(a => {
                 // Only consider truly blank SRFs in the 'New' status for the short window
                 if (a.status === NEW && utilityService.isEmptyApplication(a) && !appsMap.has(a._id)) {

--- a/services/application.js
+++ b/services/application.js
@@ -1121,12 +1121,15 @@ class Application {
             const appsDefault = await this.applicationDAO.getInactiveApplication(pastDefault, `${this._INACTIVE_REMINDER}_${day}`);
             reminderEntries.push(...(appsDefault || []).map(a => ({ application: a, pastDays: pastDefault, baseDays: defaultDays })));
 
-            const pastShort = shortDays - day;
-            const appsShort = await this.applicationDAO.getInactiveApplication(pastShort, `${this._INACTIVE_REMINDER}_${day}`);
-            if (appsShort && appsShort.length > 0) {
-                const utilityService = new UtilityService();
-                // only include blank New SRFs from short-window
-                reminderEntries.push(...appsShort.filter(a => a.status === NEW && utilityService.isEmptyApplication(a)).map(a => ({ application: a, pastDays: pastShort, baseDays: shortDays })));
+            // Only query short window for intervals strictly less than shortDays to avoid zero/negative pastDays
+            if (day < shortDays) {
+                const pastShort = shortDays - day;
+                const appsShort = await this.applicationDAO.getInactiveApplication(pastShort, `${this._INACTIVE_REMINDER}_${day}`);
+                if (appsShort && appsShort.length > 0) {
+                    const utilityService = new UtilityService();
+                    // only include blank New SRFs from short-window
+                    reminderEntries.push(...appsShort.filter(a => a.status === NEW && utilityService.isEmptyApplication(a)).map(a => ({ application: a, pastDays: pastShort, baseDays: shortDays })));
+                }
             }
         }
 

--- a/services/application.js
+++ b/services/application.js
@@ -951,8 +951,32 @@ class Application {
 
     async deleteInactiveApplications() {
         try {
-            const applications = await this.applicationDAO.getInactiveApplication(this.emailParams.inactiveDays);
-            
+            const utilityService = new UtilityService();
+            // default retention window and new short window for blank 'New' SRFs
+            const defaultDays = this.emailParams.inactiveDays;
+            const shortDays = this.emailParams.inactiveNewApplicationDays || 30;
+
+            // Fetch both sets and merge, preferring entries from the default set
+            const [defaultApps, shortApps] = await Promise.all([
+                this.applicationDAO.getInactiveApplication(defaultDays),
+                this.applicationDAO.getInactiveApplication(shortDays)
+            ]);
+
+            const appsMap = new Map();
+            (defaultApps || []).forEach(a => appsMap.set(a._id, a));
+
+            const shortIds = new Set((shortApps || []).map(a => a._id));
+            (shortApps || []).forEach(a => {
+                // Only consider truly blank SRFs in the 'New' status for the short window
+                if (a.status === NEW && utilityService.isEmptyApplication(a) && !appsMap.has(a._id)) {
+                    // mark that this record should use the short window when sending emails
+                    a._useShortWindow = true;
+                    appsMap.set(a._id, a);
+                }
+            });
+
+            const applications = Array.from(appsMap.values());
+
             // Handle undefined/null/empty applications gracefully
             if (!applications?.length) {
                 console.log("No inactive applications found to delete");
@@ -960,85 +984,89 @@ class Application {
             }
 
             console.log(`Found ${applications.length} inactive applications to process`);
-                
-                const [applicantUsers, BCCUsers] = await Promise.all([
-                    this._findUsersByApplicantIDs(applications),
-                    this.userService.getUsersByNotifications([EMAIL_NOTIFICATIONS.SUBMISSION_REQUEST.REQUEST_DELETE],
-                        [ROLES.FEDERAL_LEAD, ROLES.DATA_COMMONS_PERSONNEL, ROLES.ADMIN]),
-                ]);
 
-                const permittedUserIDs = new Set(
-                    applicantUsers
-                        ?.filter((u) => u?.notifications?.includes(EMAIL_NOTIFICATIONS.SUBMISSION_REQUEST.REQUEST_DELETE))
-                        ?.map((u) => u?._id)
-                );
-                const history = HistoryEventBuilder.createEvent("", DELETED, this._DELETE_REVIEW_COMMENT);
-                
-                // Use Promise.allSettled to handle partial failures gracefully
-                const updateResults = await Promise.allSettled(applications.map(async (app) => {
-                    const utilityService = new UtilityService();
-                    if (utilityService.isEmptyApplication(app)) {
-                        return await this.applicationDAO.delete(app._id);
+            const [applicantUsers, BCCUsers] = await Promise.all([
+                this._findUsersByApplicantIDs(applications),
+                this.userService.getUsersByNotifications([EMAIL_NOTIFICATIONS.SUBMISSION_REQUEST.REQUEST_DELETE],
+                    [ROLES.FEDERAL_LEAD, ROLES.DATA_COMMONS_PERSONNEL, ROLES.ADMIN]),
+            ]);
+
+            const permittedUserIDs = new Set(
+                applicantUsers
+                    ?.filter((u) => u?.notifications?.includes(EMAIL_NOTIFICATIONS.SUBMISSION_REQUEST.REQUEST_DELETE))
+                    ?.map((u) => u?._id)
+            );
+            const history = HistoryEventBuilder.createEvent("", DELETED, this._DELETE_REVIEW_COMMENT);
+
+            // Use Promise.allSettled to handle partial failures gracefully
+            const updateResults = await Promise.allSettled(applications.map(async (app) => {
+                if (utilityService.isEmptyApplication(app) && app.status === NEW) {
+                    // permanently delete blank 'New' SRFs
+                    return await this.applicationDAO.delete(app._id);
+                }
+                return await this.applicationDAO.update({
+                    _id: app._id,
+                    status: DELETED,
+                    updatedAt: history.dateTime,
+                    inactiveReminder: true,
+                    history: [...(app.history || []), history]
+                });
+            }));
+
+            // Count successful updates
+            const successfulUpdates = updateResults.filter(result => result.status === 'fulfilled').length;
+            const failedUpdates = updateResults.filter(result => result.status === 'rejected').length;
+
+            if (failedUpdates > 0) {
+                console.error(`Failed to update ${failedUpdates} applications:`, 
+                    updateResults.filter(result => result.status === 'rejected').map(result => result.reason));
+            }
+
+            if (successfulUpdates > 0) {
+                console.log(`Successfully processed ${successfulUpdates} inactive applications`);
+
+                // Filter applications to only include those that were successfully updated
+                const successfullyUpdatedApplications = applications.filter((app, index) => {
+                    const updateResult = updateResults[index];
+                    return updateResult && updateResult.status === 'fulfilled';
+                });
+
+                // Use Promise.allSettled for email notifications - only for successfully updated applications
+                const emailResults = await Promise.allSettled(successfullyUpdatedApplications.map(async (app) => {
+                    if (permittedUserIDs.has(app?.applicantID)) {
+                        const localEmailParams = {
+                            ...this.emailParams,
+                            inactiveDays: app._useShortWindow ? (this.emailParams.inactiveNewApplicationDays || shortDays) : this.emailParams.inactiveDays
+                        };
+                        await sendEmails.inactiveApplications(this.notificationService, localEmailParams, app?.applicant?.applicantEmail, app?.applicant?.applicantName, app, getUserEmails(BCCUsers));
                     }
-                    return await this.applicationDAO.update({
-                        _id: app._id,
-                        status: DELETED,
-                        updatedAt: history.dateTime,
-                        inactiveReminder: true,
-                        history: [...(app.history || []), history]
-                    });
                 }));
 
-                // Count successful updates
-                const successfulUpdates = updateResults.filter(result => result.status === 'fulfilled').length;
-                const failedUpdates = updateResults.filter(result => result.status === 'rejected').length;
-                
-                if (failedUpdates > 0) {
-                    console.error(`Failed to update ${failedUpdates} applications:`, 
-                        updateResults.filter(result => result.status === 'rejected').map(result => result.reason));
+                const successfulEmails = emailResults.filter(result => result.status === 'fulfilled').length;
+                const failedEmails = emailResults.filter(result => result.status === 'rejected').length;
+
+                if (failedEmails > 0) {
+                    console.error(`Failed to send ${failedEmails} email notifications:`, 
+                        emailResults.filter(result => result.status === 'rejected').map(result => result.reason));
                 }
 
-                if (successfulUpdates > 0) {
-                    console.log(`Successfully processed ${successfulUpdates} inactive applications`);
-                    
-                    // Filter applications to only include those that were successfully updated
-                    const successfullyUpdatedApplications = applications.filter((app, index) => {
-                        const updateResult = updateResults[index];
-                        return updateResult && updateResult.status === 'fulfilled';
-                    });
-                    
-                    // Use Promise.allSettled for email notifications - only for successfully updated applications
-                    const emailResults = await Promise.allSettled(successfullyUpdatedApplications.map(async (app) => {
-                        if (permittedUserIDs.has(app?.applicantID)) {
-                            await sendEmails.inactiveApplications(this.notificationService,this.emailParams, app?.applicant?.applicantEmail, app?.applicant?.applicantName, app, getUserEmails(BCCUsers));
-                        }
-                    }));
-                    
-                    const successfulEmails = emailResults.filter(result => result.status === 'fulfilled').length;
-                    const failedEmails = emailResults.filter(result => result.status === 'rejected').length;
-                    
-                    if (failedEmails > 0) {
-                        console.error(`Failed to send ${failedEmails} email notifications:`, 
-                            emailResults.filter(result => result.status === 'rejected').map(result => result.reason));
-                    }
-                    
-                    console.log(`Sent ${successfulEmails} email notifications for inactive applications`);
-                    
-                    // Use Promise.allSettled for log insertions - only for successfully updated applications
-                    const logResults = await Promise.allSettled(successfullyUpdatedApplications.map(async (app) => {
-                        this.logCollection.insert(UpdateApplicationStateEvent.createByApp(app._id, app.status, DELETED));
-                    }));
-                    
-                    const successfulLogs = logResults.filter(result => result.status === 'fulfilled').length;
-                    const failedLogs = logResults.filter(result => result.status === 'rejected').length;
-                    
-                    if (failedLogs > 0) {
-                        console.error(`Failed to log ${failedLogs} application deletions:`, 
-                            logResults.filter(result => result.status === 'rejected').map(result => result.reason));
-                    }
-                    
-                    console.log(`Logged ${successfulLogs} application deletions`);
+                console.log(`Sent ${successfulEmails} email notifications for inactive applications`);
+
+                // Use Promise.allSettled for log insertions - only for successfully updated applications
+                const logResults = await Promise.allSettled(successfullyUpdatedApplications.map(async (app) => {
+                    this.logCollection.insert(UpdateApplicationStateEvent.createByApp(app._id, app.status, DELETED));
+                }));
+
+                const successfulLogs = logResults.filter(result => result.status === 'fulfilled').length;
+                const failedLogs = logResults.filter(result => result.status === 'rejected').length;
+
+                if (failedLogs > 0) {
+                    console.error(`Failed to log ${failedLogs} application deletions:`, 
+                        logResults.filter(result => result.status === 'rejected').map(result => result.reason));
                 }
+
+                console.log(`Logged ${successfulLogs} application deletions`);
+            }
         } catch (error) {
             console.error("Error in deleteInactiveApplications task:", error);
             throw error; // Re-throw to be caught by cron job handler
@@ -1046,69 +1074,88 @@ class Application {
     }
 
     async remindApplicationSubmission() {
-        // The system sends an email reminder a day before the data submission expires
-        const finalInactiveApplications = await this.applicationDAO.getInactiveApplication(this.emailParams.inactiveDays - 1, this._FINAL_INACTIVE_REMINDER)
-        if (finalInactiveApplications?.length > 0) {
-            await Promise.all(finalInactiveApplications.map(async (aApplication) => {
-                await this._sendEmailFinalInactiveApplication(aApplication);
+        // The system sends reminder emails for both the default window and the short-window for blank 'New' SRFs.
+        const defaultDays = this.emailParams.inactiveDays;
+        const shortDays = this.emailParams.inactiveNewApplicationDays || 30;
+
+        // Final (24 hour) reminders for default and short windows
+        const [finalDefault, finalShort] = await Promise.all([
+            this.applicationDAO.getInactiveApplication(defaultDays - 1, this._FINAL_INACTIVE_REMINDER),
+            this.applicationDAO.getInactiveApplication(shortDays - 1, this._FINAL_INACTIVE_REMINDER)
+        ]);
+
+        // Send final reminders for default window
+        if (finalDefault?.length > 0) {
+            await Promise.all(finalDefault.map(async (aApplication) => {
+                await this._sendEmailFinalInactiveApplication(aApplication, defaultDays);
             }));
-            const applicationIDs = finalInactiveApplications
-                .map(application => application._id);
+            const applicationIDs = finalDefault.map(application => application._id);
             const query = {_id: {$in: applicationIDs}};
-            // Disable all reminders to ensure no notifications are sent.
             const everyReminderDays = this._getEveryReminderQuery(this.emailParams.inactiveApplicationNotifyDays, true);
             const updatedReminder = await this.applicationDAO.updateMany(query, everyReminderDays);
             if (!updatedReminder?.matchedCount) {
                 console.error("The email reminder flag intended to notify the inactive submission request (FINAL) is not being stored", `applicationIDs: ${applicationIDs.join(', ')}`);
             }
         }
-        // Map over inactiveDays to create an array of tuples [day, promise]
-        const inactiveApplicationsPromises = [];
-        for (const day of this.emailParams.inactiveApplicationNotifyDays) {
-            const pastInactiveDays = this.emailParams.inactiveDays - day;
-            inactiveApplicationsPromises.push([pastInactiveDays, await this.applicationDAO.getInactiveApplication(pastInactiveDays, `${this._INACTIVE_REMINDER}_${day}`)]);
-        }
-        const inactiveApplicationsResult = await Promise.all(inactiveApplicationsPromises);
-        const inactiveApplicationMapByDays = inactiveApplicationsResult.reduce((acc, [key, value]) => {
-            acc[key] = value;
-            return acc;
-        }, {});
-        // For Sorting, the oldest submission about to expire submission will be sent at once.
-        const sortedKeys = Object.keys(inactiveApplicationMapByDays).sort((a, b) => b - a);
-        let uniqueSet = new Set();  // Set to track used _id values
-        sortedKeys.forEach((key) => {
-            // Filter out _id values that have already been used
-            inactiveApplicationMapByDays[key] = inactiveApplicationMapByDays[key].filter(obj => {
-                if (!uniqueSet.has(obj._id)) {
-                    uniqueSet.add(obj._id);
-                    return true;  // Keep this object
-                }
-                return false;  // Remove this object as it's already been used
-            });
-        });
 
-        if (uniqueSet.size > 0) {
-            const emailPromises = [];
-            let inactiveApplications = [];
-            for (const [pastDays, aApplicationArray] of Object.entries(inactiveApplicationMapByDays)) {
-                for (const aApplication of aApplicationArray) {
-                    const emailPromise = (async (pastDays) => {
-                        // by default, final reminder 180 days
-                        await this._sendEmailInactiveApplication(aApplication, pastDays);
-                    })(pastDays);
-                    emailPromises.push(emailPromise);
-                    inactiveApplications.push([aApplication?._id, pastDays]);
+        // Send final reminders for short window, but only for blank 'New' SRFs
+        if (finalShort?.length > 0) {
+            const utilityService = new UtilityService();
+            const shortFinalToSend = finalShort.filter(a => a.status === NEW && utilityService.isEmptyApplication(a));
+            await Promise.all(shortFinalToSend.map(async (aApplication) => {
+                await this._sendEmailFinalInactiveApplication(aApplication, shortDays);
+            }));
+            const applicationIDs = shortFinalToSend.map(application => application._id);
+            if (applicationIDs.length > 0) {
+                const query = {_id: {$in: applicationIDs}};
+                const everyReminderDays = this._getEveryReminderQuery(this.emailParams.inactiveApplicationNotifyDays, true);
+                const updatedReminder = await this.applicationDAO.updateMany(query, everyReminderDays);
+                if (!updatedReminder?.matchedCount) {
+                    console.error("The email reminder flag intended to notify the inactive submission request (FINAL) is not being stored", `applicationIDs: ${applicationIDs.join(', ')}`);
                 }
             }
-            await Promise.all(emailPromises);
-            const submissionReminderDays = this.emailParams.inactiveApplicationNotifyDays;
-            for (const inactiveApplication of inactiveApplications) {
-                const applicationID = inactiveApplication[0];
-                const pastDays = inactiveApplication[1];
-                const expiredDays = this.emailParams.inactiveDays - pastDays;
+        }
+
+        // Build list of reminders for notification intervals for default and short windows
+        const reminderEntries = [];
+        for (const day of this.emailParams.inactiveApplicationNotifyDays) {
+            const pastDefault = defaultDays - day;
+            const appsDefault = await this.applicationDAO.getInactiveApplication(pastDefault, `${this._INACTIVE_REMINDER}_${day}`);
+            reminderEntries.push(...(appsDefault || []).map(a => ({ application: a, pastDays: pastDefault, baseDays: defaultDays })));
+
+            const pastShort = shortDays - day;
+            const appsShort = await this.applicationDAO.getInactiveApplication(pastShort, `${this._INACTIVE_REMINDER}_${day}`);
+            if (appsShort && appsShort.length > 0) {
+                const utilityService = new UtilityService();
+                // only include blank New SRFs from short-window
+                reminderEntries.push(...appsShort.filter(a => a.status === NEW && utilityService.isEmptyApplication(a)).map(a => ({ application: a, pastDays: pastShort, baseDays: shortDays })));
+            }
+        }
+
+        if (reminderEntries.length > 0) {
+            // Sort by pastDays descending (older first) and dedupe by application id
+            reminderEntries.sort((a, b) => b.pastDays - a.pastDays);
+            const seen = new Set();
+            const toSend = [];
+            for (const entry of reminderEntries) {
+                if (!seen.has(entry.application._id)) {
+                    seen.add(entry.application._id);
+                    toSend.push(entry);
+                }
+            }
+
+            // Send emails
+            await Promise.all(toSend.map(async (entry) => {
+                await this._sendEmailInactiveApplication(entry.application, entry.pastDays, entry.baseDays);
+            }));
+
+            // Update reminder flags based on baseDays
+            for (const entry of toSend) {
+                const applicationID = entry.application._id;
+                const pastDays = entry.pastDays;
+                const expiredDays = entry.baseDays - pastDays;
+                const submissionReminderDays = this.emailParams.inactiveApplicationNotifyDays;
                 const reminderDays = submissionReminderDays.filter((d) => expiredDays < d || expiredDays === d);
-                // The applications with the closest expiration dates will be flagged as true; no sent any notification anymore
-                // A notification will be sent at each interval. ex) 7, 30, 60 days before expiration
                 const reminderFilter = reminderDays.reduce((acc, day) => {
                     acc[`${this._INACTIVE_REMINDER}_${day}`] = true;
                     return acc;
@@ -1270,7 +1317,7 @@ class Application {
 
     }
 
-    async _sendEmailFinalInactiveApplication(application) {
+    async _sendEmailFinalInactiveApplication(application, baseInactiveDays = this.emailParams.inactiveDays) {
         const [aSubmitter, BCCUsers] = await Promise.all([
             this.userService.getUserByID(application?.applicantID),
             this.userService.getUsersByNotifications([EMAIL_NOTIFICATIONS.SUBMISSION_REQUEST.REQUEST_EXPIRING],
@@ -1295,14 +1342,14 @@ class Application {
                     firstName: `${aSubmitter?.firstName} ${aSubmitter?.lastName || ''}`,
                     studyName: studyName?.length > 0 ? studyName : "N/A"
                 },{
-                    inactiveDays: this.emailParams.inactiveDays,
+                    inactiveDays: baseInactiveDays,
                     url: this.emailParams.url
                 });
-            logDaysDifference(this.emailParams.inactiveDays - 1, application?.updatedAt, application?._id);
+            logDaysDifference(baseInactiveDays - 1, application?.updatedAt, application?._id);
         }
     }
 
-    async _sendEmailInactiveApplication(application, interval) {
+    async _sendEmailInactiveApplication(application, interval, baseInactiveDays = this.emailParams.inactiveDays) {
         const [aSubmitter, BCCUsers] = await Promise.all([
             this.userService.getUserByID(application?.applicantID),
             this.userService.getUsersByNotifications([EMAIL_NOTIFICATIONS.SUBMISSION_REQUEST.REQUEST_EXPIRING],
@@ -1327,7 +1374,7 @@ class Application {
                     firstName: `${aSubmitter?.firstName} ${aSubmitter?.lastName || ''}`,
                     studyName: studyName?.length > 0 ? studyName : "N/A"
                 },{
-                    remainDays: this.emailParams.inactiveDays - interval,
+                    remainDays: baseInactiveDays - interval,
                     inactiveDays: interval,
                     url: this.emailParams.url
                 });

--- a/test/documentation/3-6-0/add-short-inactive-application-config.test.js
+++ b/test/documentation/3-6-0/add-short-inactive-application-config.test.js
@@ -1,0 +1,90 @@
+const { addShortInactiveApplicationConfig } = require('../../../documentation/3-6-0/add-short-inactive-application-config');
+
+describe('Add Short Inactive Application Configuration Migration', () => {
+    let mockDb;
+    let mockConfigCollection;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        mockConfigCollection = {
+            updateOne: jest.fn()
+        };
+
+        mockDb = {
+            collection: jest.fn(() => mockConfigCollection)
+        };
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should access the configuration collection', async () => {
+        mockConfigCollection.updateOne.mockResolvedValue({ upsertedCount: 0, modifiedCount: 1 });
+
+        await addShortInactiveApplicationConfig(mockDb);
+
+        expect(mockDb.collection).toHaveBeenCalledWith('configuration');
+    });
+
+    it('should upsert SCHEDULED_JOBS document if missing', async () => {
+        mockConfigCollection.updateOne
+            .mockResolvedValueOnce({ upsertedCount: 1, modifiedCount: 0 }) // upsert
+            .mockResolvedValueOnce({ modifiedCount: 1 }); // set key
+
+        const result = await addShortInactiveApplicationConfig(mockDb);
+
+        expect(mockConfigCollection.updateOne).toHaveBeenCalledWith(
+            { type: 'SCHEDULED_JOBS' },
+            { $setOnInsert: { _id: expect.any(String), type: 'SCHEDULED_JOBS' } },
+            { upsert: true }
+        );
+        expect(result).toEqual({ success: true, added: true });
+    });
+
+    it('should add INACTIVE_NEW_APPLICATION_DAYS key with default value 30', async () => {
+        mockConfigCollection.updateOne
+            .mockResolvedValueOnce({ upsertedCount: 0, modifiedCount: 0 }) // upsert no-op
+            .mockResolvedValueOnce({ modifiedCount: 1 }); // key added
+
+        await addShortInactiveApplicationConfig(mockDb);
+
+        expect(mockConfigCollection.updateOne).toHaveBeenCalledWith(
+            { type: 'SCHEDULED_JOBS', 'INACTIVE_NEW_APPLICATION_DAYS': { $eq: null } },
+            { $set: { 'INACTIVE_NEW_APPLICATION_DAYS': 30 } }
+        );
+    });
+
+    it('should skip when configuration already has the key', async () => {
+        mockConfigCollection.updateOne
+            .mockResolvedValueOnce({ upsertedCount: 0, modifiedCount: 0 }) // upsert no-op
+            .mockResolvedValueOnce({ modifiedCount: 0 }); // key already exists
+
+        const result = await addShortInactiveApplicationConfig(mockDb);
+
+        expect(result).toEqual({ success: true, skipped: true });
+    });
+
+    it('should return success false on error', async () => {
+        mockConfigCollection.updateOne.mockRejectedValue(new Error('db error'));
+
+        const result = await addShortInactiveApplicationConfig(mockDb);
+
+        expect(result).toEqual({ success: false, error: 'db error' });
+    });
+
+    it('should return success true and added when key is newly added', async () => {
+        mockConfigCollection.updateOne
+            .mockResolvedValueOnce({ upsertedCount: 0, modifiedCount: 0 })
+            .mockResolvedValueOnce({ modifiedCount: 1 });
+
+        const result = await addShortInactiveApplicationConfig(mockDb);
+
+        expect(result.success).toBe(true);
+        expect(result.added).toBe(true);
+    });
+});

--- a/test/services/application.deleteInactiveApplications.test.js
+++ b/test/services/application.deleteInactiveApplications.test.js
@@ -17,6 +17,7 @@ const mockNotificationsService = {
 };
 const mockEmailParams = {
     inactiveDays: 180,
+    inactiveNewApplicationDays: 30,
     url: 'http://test.com',
     officialEmail: 'test@example.com'
 };
@@ -96,7 +97,8 @@ describe('deleteInactiveApplications Error Handling', () => {
 
     describe('Error Handling Improvements', () => {
         test('should handle database query failures with try-catch', async () => {
-            mockApplicationDAO.getInactiveApplication.mockRejectedValue(new Error('Database connection failed'));
+            mockApplicationDAO.getInactiveApplication
+                .mockRejectedValueOnce(new Error('Database connection failed'));
 
             const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
@@ -109,7 +111,9 @@ describe('deleteInactiveApplications Error Handling', () => {
         });
 
         test('should handle no inactive applications gracefully', async () => {
-            mockApplicationDAO.getInactiveApplication.mockResolvedValue([]);
+            mockApplicationDAO.getInactiveApplication
+                .mockResolvedValueOnce([]) // default window
+                .mockResolvedValueOnce([]); // short window
 
             const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
@@ -124,7 +128,9 @@ describe('deleteInactiveApplications Error Handling', () => {
         });
 
         test('should handle undefined applications array gracefully', async () => {
-            mockApplicationDAO.getInactiveApplication.mockResolvedValue(undefined);
+            mockApplicationDAO.getInactiveApplication
+                .mockResolvedValueOnce(undefined) // default window
+                .mockResolvedValueOnce(undefined); // short window
 
             const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
@@ -145,12 +151,15 @@ describe('deleteInactiveApplications Error Handling', () => {
                     applicantID: 'user1',
                     applicant: { applicantEmail: 'user1@test.com', applicantName: 'User 1' },
                     studyAbbreviation: 'TEST-STUDY',
+                    status: 'In Progress',
                     history: [],
                     updatedAt: new Date('2023-01-01')
                 }
             ];
 
-            mockApplicationDAO.getInactiveApplication.mockResolvedValue(mockApplications);
+            mockApplicationDAO.getInactiveApplication
+                .mockResolvedValueOnce(mockApplications) // default window
+                .mockResolvedValueOnce([]); // short window
             mockUserService.getUsersByNotifications.mockResolvedValue([]);
             mockUserService.userCollection.aggregate.mockResolvedValue([]);
             mockApplicationDAO.update.mockResolvedValue({});
@@ -175,6 +184,7 @@ describe('deleteInactiveApplications Error Handling', () => {
                     applicantID: 'user1',
                     applicant: { applicantEmail: 'user1@test.com', applicantName: 'User 1' },
                     studyAbbreviation: 'TEST-STUDY',
+                    status: 'In Progress',
                     history: [],
                     updatedAt: new Date('2023-01-01')
                 },
@@ -183,12 +193,15 @@ describe('deleteInactiveApplications Error Handling', () => {
                     applicantID: 'user2',
                     applicant: { applicantEmail: 'user2@test.com', applicantName: 'User 2' },
                     studyAbbreviation: 'TEST-STUDY-2',
+                    status: 'In Progress',
                     history: [],
                     updatedAt: new Date('2023-01-01')
                 }
             ];
 
-            mockApplicationDAO.getInactiveApplication.mockResolvedValue(mockApplications);
+            mockApplicationDAO.getInactiveApplication
+                .mockResolvedValueOnce(mockApplications) // default window
+                .mockResolvedValueOnce([]); // short window
             mockUserService.getUsersByNotifications.mockResolvedValue([]);
             mockUserService.userCollection.aggregate.mockResolvedValue([]);
             
@@ -222,6 +235,7 @@ describe('deleteInactiveApplications Error Handling', () => {
                     applicantID: 'user1',
                     applicant: { applicantEmail: 'user1@test.com', applicantName: 'User 1' },
                     studyAbbreviation: 'TEST-STUDY',
+                    status: 'In Progress',
                     history: [],
                     updatedAt: new Date('2023-01-01')
                 },
@@ -230,12 +244,15 @@ describe('deleteInactiveApplications Error Handling', () => {
                     applicantID: 'user2',
                     applicant: { applicantEmail: 'user2@test.com', applicantName: 'User 2' },
                     studyAbbreviation: 'TEST-STUDY-2',
+                    status: 'In Progress',
                     history: [],
                     updatedAt: new Date('2023-01-01')
                 }
             ];
 
-            mockApplicationDAO.getInactiveApplication.mockResolvedValue(mockApplications);
+            mockApplicationDAO.getInactiveApplication
+                .mockResolvedValueOnce(mockApplications) // default window
+                .mockResolvedValueOnce([]); // short window
             mockUserService.getUsersByNotifications.mockResolvedValue([]);
             mockUserService.userCollection.aggregate.mockResolvedValue([]);
             
@@ -262,6 +279,62 @@ describe('deleteInactiveApplications Error Handling', () => {
             } finally {
                 consoleSpy.mockRestore();
                 consoleErrorSpy.mockRestore();
+            }
+        });
+
+        test('should detect and permanently delete blank New SRFs', async () => {
+            const mockDefaultApps = [
+                {
+                    _id: 'app1',
+                    applicantID: 'user1',
+                    applicant: { applicantEmail: 'user1@test.com', applicantName: 'User 1' },
+                    studyAbbreviation: 'TEST-STUDY',
+                    status: 'In Progress',
+                    programName: 'Program1',
+                    history: [],
+                    updatedAt: new Date('2023-01-01')
+                }
+            ];
+
+            const mockShortApps = [
+                {
+                    _id: 'app2',
+                    applicantID: 'user2',
+                    applicant: { applicantEmail: 'user2@test.com', applicantName: 'User 2' },
+                    studyAbbreviation: undefined,
+                    studyName: undefined,
+                    programName: undefined,
+                    status: 'New',
+                    ORCID: undefined,
+                    PI: undefined,
+                    programAbbreviation: undefined,
+                    programDescription: undefined,
+                    history: [],
+                    updatedAt: new Date('2023-01-01')
+                }
+            ];
+
+            mockApplicationDAO.getInactiveApplication
+                .mockResolvedValueOnce(mockDefaultApps) // default window
+                .mockResolvedValueOnce(mockShortApps); // short window
+            mockUserService.getUsersByNotifications.mockResolvedValue([]);
+            mockUserService.userCollection.aggregate.mockResolvedValue([]);
+            mockApplicationDAO.update.mockResolvedValue({});
+            mockApplicationDAO.delete.mockResolvedValue({});
+
+            const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+            try {
+                await applicationService.deleteInactiveApplications();
+
+                // Should have 2 apps total (one from default, one blank from short)
+                expect(consoleSpy).toHaveBeenCalledWith('Found 2 inactive applications to process');
+                // delete should be called for blank New SRF
+                expect(mockApplicationDAO.delete).toHaveBeenCalledWith('app2');
+                // update should be called for the default app
+                expect(mockApplicationDAO.update).toHaveBeenCalled();
+            } finally {
+                consoleSpy.mockRestore();
             }
         });
     });

--- a/test/services/application.remindApplicationSubmission.test.js
+++ b/test/services/application.remindApplicationSubmission.test.js
@@ -252,5 +252,43 @@ describe('remindApplicationSubmission', () => {
         })
       );
     });
+
+    it('should skip short window queries when day >= shortDays to prevent bulk matches', async () => {
+      // Final reminders
+      mockApplicationDAO.getInactiveApplication
+        .mockResolvedValueOnce([]) // final default
+        .mockResolvedValueOnce([]); // final short
+
+      mockApplicationDAO.updateMany.mockResolvedValue({ matchedCount: 0 });
+
+      // For interval reminders with [7, 15, 30] and shortDays=30:
+      // day=7: query both (7 < 30) ✓
+      // day=15: query both (15 < 30) ✓
+      // day=30: skip short (30 >= 30) ✗ prevents getInactiveApplication(0, ...)
+      mockApplicationDAO.getInactiveApplication
+        .mockResolvedValueOnce([]) // 7 days default
+        .mockResolvedValueOnce([]) // 7 days short (should be called)
+        .mockResolvedValueOnce([]) // 15 days default
+        .mockResolvedValueOnce([]) // 15 days short (should be called)
+        .mockResolvedValueOnce([]); // 30 days default
+      // 30 days short should NOT be called
+
+      mockApplicationDAO.update.mockResolvedValue({ matchedCount: 0 });
+
+      await applicationService.remindApplicationSubmission();
+
+      // Verify getInactiveApplication was called exactly 7 times:
+      // 2 final (default + short) + 5 interval (only 1 short query for 7 and 15, skipped for 30)
+      expect(mockApplicationDAO.getInactiveApplication).toHaveBeenCalledTimes(7);
+
+      // Verify it was called for 7 days short
+      expect(mockApplicationDAO.getInactiveApplication).toHaveBeenCalledWith(23, 'inactiveReminder_7');
+      // Verify it was called for 15 days short
+      expect(mockApplicationDAO.getInactiveApplication).toHaveBeenCalledWith(15, 'inactiveReminder_15');
+      // Verify it was NOT called with 0 (which would match too many apps)
+      const allCalls = mockApplicationDAO.getInactiveApplication.mock.calls;
+      const zeroOrNegativeCalls = allCalls.filter(([days]) => days <= 0);
+      expect(zeroOrNegativeCalls).toHaveLength(0);
+    });
   });
 });

--- a/test/services/application.remindApplicationSubmission.test.js
+++ b/test/services/application.remindApplicationSubmission.test.js
@@ -1,0 +1,256 @@
+const { Application } = require('../../services/application');
+
+const mockLogCollection = { insert: jest.fn() };
+const mockApplicationCollection = {};
+const mockApprovedStudiesService = {};
+const mockUserService = {
+  getUsersByNotifications: jest.fn(),
+  getUserByID: jest.fn(),
+  userCollection: {
+    find: jest.fn(),
+    aggregate: jest.fn()
+  }
+};
+const mockDbService = {};
+const mockNotificationsService = {
+  finalRemindApplicationsNotification: jest.fn(),
+  remindApplicationsNotification: jest.fn()
+};
+const mockEmailParams = {
+  inactiveDays: 180,
+  inactiveNewApplicationDays: 30,
+  url: 'http://test.com',
+  officialEmail: 'test@example.com',
+  inactiveApplicationNotifyDays: [7, 15, 30]
+};
+const mockOrganizationService = {};
+const mockConfigurationService = {};
+
+describe('remindApplicationSubmission', () => {
+  let applicationService;
+  let mockApplicationDAO;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(console, 'log').mockImplementation(() => { });
+    jest.spyOn(console, 'error').mockImplementation(() => { });
+
+    global.DELETED = 'DELETED';
+    global.NEW = 'New';
+    global.EMAIL_NOTIFICATIONS = {
+      SUBMISSION_REQUEST: {
+        REQUEST_EXPIRING: 'REQUEST_EXPIRING'
+      }
+    };
+    global.ROLES = {
+      FEDERAL_LEAD: 'FEDERAL_LEAD',
+      DATA_COMMONS_PERSONNEL: 'DATA_COMMONS_PERSONNEL',
+      ADMIN: 'ADMIN'
+    };
+
+    mockApplicationDAO = {
+      getInactiveApplication: jest.fn(),
+      updateMany: jest.fn(),
+      update: jest.fn()
+    };
+
+    applicationService = new Application(
+      mockLogCollection,
+      mockApplicationCollection,
+      mockApprovedStudiesService,
+      mockUserService,
+      mockDbService,
+      mockNotificationsService,
+      mockEmailParams,
+      mockOrganizationService,
+      null,
+      mockConfigurationService,
+      null
+    );
+
+    applicationService.applicationDAO = mockApplicationDAO;
+    applicationService.userDAO = { findFirst: jest.fn() };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Dual-window reminder logic', () => {
+    it('should fetch applications from both default and short windows', async () => {
+      // All empty - no reminders to send
+      mockApplicationDAO.getInactiveApplication
+        .mockResolvedValueOnce([]) // final default
+        .mockResolvedValueOnce([]); // final short
+
+      mockApplicationDAO.updateMany.mockResolvedValue({ matchedCount: 0 });
+
+      // No interval reminders
+      for (let i = 0; i < 6; i++) {
+        mockApplicationDAO.getInactiveApplication.mockResolvedValueOnce([]);
+      }
+
+      await applicationService.remindApplicationSubmission();
+
+      // Should have called getInactiveApplication at least twice (final default + final short)
+      const calls = mockApplicationDAO.getInactiveApplication.mock.calls;
+      expect(calls.length).toBeGreaterThanOrEqual(2);
+      // First two calls should be for final reminders
+      expect(calls[0][1]).toBe('finalInactiveReminder'); // default window
+      expect(calls[1][1]).toBe('finalInactiveReminder'); // short window
+    });
+
+    it('should only send short window reminders for blank New SRFs', async () => {
+      const mockBlankNewApp = {
+        _id: 'app-blank-new',
+        applicantID: 'user-blank',
+        studyAbbreviation: undefined,
+        studyName: undefined,
+        programName: undefined,
+        status: 'New',
+        ORCID: undefined,
+        PI: undefined,
+        programAbbreviation: undefined,
+        programDescription: undefined,
+        history: [],
+        updatedAt: new Date('2023-01-01')
+      };
+
+      const mockRegularApp = {
+        _id: 'app-regular',
+        applicantID: 'user-regular',
+        studyName: 'Regular Study',
+        status: 'In Progress',
+        history: [],
+        updatedAt: new Date('2023-01-01')
+      };
+
+      // Final reminders
+      mockApplicationDAO.getInactiveApplication
+        .mockResolvedValueOnce([mockRegularApp]) // final default - has study name
+        .mockResolvedValueOnce([mockBlankNewApp, mockRegularApp]); // final short - both present
+
+      mockApplicationDAO.updateMany.mockResolvedValue({ matchedCount: 0 });
+
+      // No interval reminders
+      for (let i = 0; i < 6; i++) {
+        mockApplicationDAO.getInactiveApplication.mockResolvedValueOnce([]);
+      }
+
+      mockUserService.getUsersByNotifications.mockResolvedValue([
+        { _id: 'user-blank', email: 'blank@example.com' },
+        { _id: 'user-regular', email: 'regular@example.com' }
+      ]);
+
+      mockUserService.getUserByID.mockResolvedValue({
+        _id: 'user-test',
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'test@example.com'
+      });
+
+      mockUserService.userCollection.find.mockResolvedValue([]);
+      applicationService.userDAO.findFirst.mockResolvedValue(null);
+
+      await applicationService.remindApplicationSubmission();
+
+      // getInactiveApplication should have been called
+      expect(mockApplicationDAO.getInactiveApplication).toHaveBeenCalled();
+    });
+
+    it('should track and deduplicate reminders across intervals', async () => {
+      const mockApp = {
+        _id: 'app-tracked',
+        applicantID: 'user-tracked',
+        studyAbbreviation: 'TRACK',
+        status: 'In Progress',
+        history: [],
+        updatedAt: new Date('2023-01-01')
+      };
+
+      // Final reminders
+      mockApplicationDAO.getInactiveApplication
+        .mockResolvedValueOnce([]) // final default
+        .mockResolvedValueOnce([]); // final short
+
+      mockApplicationDAO.updateMany.mockResolvedValue({ matchedCount: 0 });
+
+      // Same app appears in multiple intervals (simulating it's returning at different reminder intervals)
+      mockApplicationDAO.getInactiveApplication
+        .mockResolvedValueOnce([mockApp]) // 7 days default
+        .mockResolvedValueOnce([]) // 7 days short
+        .mockResolvedValueOnce([mockApp]) // 15 days default
+        .mockResolvedValueOnce([]) // 15 days short
+        .mockResolvedValueOnce([mockApp]) // 30 days default
+        .mockResolvedValueOnce([]); // 30 days short
+
+      mockApplicationDAO.update.mockResolvedValue({ matchedCount: 1 });
+
+      mockUserService.getUserByID.mockResolvedValue({
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'test@example.com',
+        notifications: ['REQUEST_EXPIRING']
+      });
+
+      mockUserService.getUsersByNotifications.mockResolvedValue([]);
+      mockUserService.userCollection.find.mockResolvedValue([{ id: 'user-tracked', email: 'test@example.com' }]);
+      applicationService.userDAO.findFirst.mockResolvedValue({ id: 'user-tracked', email: 'test@example.com' });
+
+      await applicationService.remindApplicationSubmission();
+
+      // Should have called update for the deduped app
+      expect(mockApplicationDAO.update).toHaveBeenCalled();
+    });
+
+    it('should set reminder flags after sending emails', async () => {
+      const mockApp = {
+        _id: 'app-flag-test',
+        applicantID: 'user-flag-test',
+        studyAbbreviation: 'FLAG',
+        status: 'In Progress',
+        history: [],
+        updatedAt: new Date('2023-01-01')
+      };
+
+      // Final reminders
+      mockApplicationDAO.getInactiveApplication
+        .mockResolvedValueOnce([]) // final default
+        .mockResolvedValueOnce([]); // final short
+
+      mockApplicationDAO.updateMany.mockResolvedValue({ matchedCount: 0 });
+
+      // 7-day interval has app
+      mockApplicationDAO.getInactiveApplication
+        .mockResolvedValueOnce([mockApp]) // 7 days default
+        .mockResolvedValueOnce([]) // 7 days short
+        .mockResolvedValueOnce([]) // 15 days default
+        .mockResolvedValueOnce([]) // 15 days short
+        .mockResolvedValueOnce([]) // 30 days default
+        .mockResolvedValueOnce([]); // 30 days short
+
+      mockApplicationDAO.update.mockResolvedValue({ matchedCount: 1 });
+
+      mockUserService.getUserByID.mockResolvedValue({
+        firstName: 'Flag',
+        lastName: 'Test',
+        email: 'flag@example.com',
+        notifications: ['REQUEST_EXPIRING']
+      });
+
+      mockUserService.getUsersByNotifications.mockResolvedValue([]);
+      mockUserService.userCollection.find.mockResolvedValue([{ id: 'user-flag-test', email: 'flag@example.com' }]);
+      applicationService.userDAO.findFirst.mockResolvedValue({ id: 'user-flag-test', email: 'flag@example.com' });
+
+      await applicationService.remindApplicationSubmission();
+
+      // Verify update was called with reminder flags
+      expect(mockApplicationDAO.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: 'app-flag-test'
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Overview

This PR introduces a new configuration option to reduce the auto-deletion window for new submission request forms.

### Change Details (Specifics)

- Added `INACTIVE_NEW_APPLICATION_DAYS` configuration (default 30 days) for new blank applications
- Created a migration to add the new configuration to the DB
- Modified inactive application handler to fetch applications using both default and 30-day windows
- Changed blank applications in "New" status to be permanently deleted instead of marked DELETED
- Updated email notifications to use appropriate inactivity window based on application type

### Related Ticket(s)

CRDCDH-3632 (Task)
CRDCDH-3598 (US)