### PR TITLE
3703: Contextually handle empty study abbreviation

### DIFF
--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -28,6 +28,7 @@ const {ApprovedStudiesService} = require("../services/approved-studies");
 const {BatchService, UploadingMonitor} = require("../services/batch-service");
 const {S3Service} = require("../services/s3-service");
 const {Organization} = require("../crdc-datahub-database-drivers/services/organization");
+const {applyStudyAbbreviationFallbackToListPrograms} = require("../utility/study-abbrev-helpers");
 const {DataRecordService} = require("../services/data-record-service");
 const {UtilityService} = require("../services/utility");
 const {InstitutionService} = require("../services/institution-service");
@@ -224,7 +225,10 @@ dbConnector.connect().then(async () => {
         editUser : userService.editUser.bind(userService),
         grantToken : userService.grantToken.bind(userService),
         listActiveDCPs: userService.listActiveDCPsAPI.bind(userService),
-        listPrograms : organizationService.listPrograms.bind(organizationService),
+        listPrograms: async (params, context) => {
+            const result = await organizationService.listPrograms(params, context);
+            return applyStudyAbbreviationFallbackToListPrograms(result);
+        },
         getOrganization : async (params, context) => {
             const userScope = await getOrgUserScope(authorizationService, context?.userInfo, ADMIN.MANAGE_PROGRAMS);
             if (userScope.isNoneScope()) {

--- a/services/application.js
+++ b/services/application.js
@@ -11,6 +11,7 @@ const {CreateApplicationEvent, UpdateApplicationStateEvent} = require("../crdc-d
 const ROLES = USER_CONSTANTS.USER.ROLES;
 const {parseJsonString, isTrue} = require("../crdc-datahub-database-drivers/utility/string-utility");
 const {isUndefined, replaceErrorString} = require("../utility/string-util");
+const {defaultStudyAbbreviationToStudyName, defaultStudyAbbreviationToNA} = require("../utility/study-abbrev-helpers");
 const {EMAIL_NOTIFICATIONS} = require("../crdc-datahub-database-drivers/constants/user-permission-constants");
 const USER_PERMISSION_CONSTANTS = require("../crdc-datahub-database-drivers/constants/user-permission-constants");
 const {UserScope} = require("../domain/user-scope");
@@ -601,7 +602,11 @@ class Application {
                 applicantEmail: app?.applicant ? app?.applicant?.email : "",
             };
             if (!this._isApprovedApplication(app)) {
-                mappedApplications.push({ ...app, applicant });
+                mappedApplications.push({
+                    ...app,
+                    applicant,
+                    studyAbbreviation: defaultStudyAbbreviationToStudyName(app.studyAbbreviation, app.studyName),
+                });
                 continue;
             }
             const { conditional, pendingConditions } = await this._computeConditionalApprovalFields(app.studyName);
@@ -610,6 +615,7 @@ class Application {
                 applicant,
                 conditional,
                 pendingConditions,
+                studyAbbreviation: defaultStudyAbbreviationToStudyName(app.studyAbbreviation, app.studyName),
             });
         }
         applications = mappedApplications;
@@ -1161,7 +1167,7 @@ class Application {
                         reviewComments: comment && comment?.trim()?.length > 0 ? comment?.trim() : "N/A"
                     },
                     {
-                        study: application?.studyAbbreviation,
+                        study: studyLabelForEmailBody(application),
                         contactEmail: `${this.emailParams.conditionalSubmissionContact}.`
                     }
                 );
@@ -1284,7 +1290,6 @@ class Application {
         }
 
         if (aSubmitter?.notifications?.includes(EMAIL_NOTIFICATIONS.SUBMISSION_REQUEST.REQUEST_EXPIRING)) {
-            const studyName = application?.studyAbbreviation?.trim();
             const applicant = await this.userDAO.findFirst({id: application?.applicantID});
             const CCEmails = getCCEmails(applicant?.email, application);
             const toBCCEmails = getUserEmails(filteredBCCUsers)
@@ -1293,7 +1298,7 @@ class Application {
                 CCEmails,
                 toBCCEmails, {
                     firstName: `${aSubmitter?.firstName} ${aSubmitter?.lastName || ''}`,
-                    studyName: studyName?.length > 0 ? studyName : "N/A"
+                    studyName: studyLabelForEmailBody(application)
                 },{
                     inactiveDays: this.emailParams.inactiveDays,
                     url: this.emailParams.url
@@ -1315,7 +1320,6 @@ class Application {
         }
 
         if (aSubmitter?.notifications?.includes(EMAIL_NOTIFICATIONS.SUBMISSION_REQUEST.REQUEST_EXPIRING)) {
-            const studyName = application?.studyAbbreviation?.trim();
             const applicant = await this.userDAO.findFirst({id: application?.applicantID});
             const CCEmails = getCCEmails(applicant?.email, application);
             const filteredBCCUsers = BCCUsers.filter((u) => u?._id !== aSubmitter?._id);
@@ -1325,7 +1329,7 @@ class Application {
                 CCEmails,
                 toBCCEmails, {
                     firstName: `${aSubmitter?.firstName} ${aSubmitter?.lastName || ''}`,
-                    studyName: studyName?.length > 0 ? studyName : "N/A"
+                    studyName: studyLabelForEmailBody(application)
                 },{
                     remainDays: this.emailParams.inactiveDays - interval,
                     inactiveDays: interval,
@@ -1344,8 +1348,8 @@ class Application {
     }
 
     async _saveApprovedStudies(aApplication, questionnaire, pendingModelChange, pendingImageDeIdentification, isPendingGPA, existingProgram) {
-        // use study name when study abbreviation is not available
-        const studyAbbreviation = !!aApplication?.studyAbbreviation?.trim() ? aApplication?.studyAbbreviation : questionnaire?.study?.name;
+        // Only the application field (user input); do not substitute study name or questionnaire when missing
+        const studyAbbreviation = (aApplication?.studyAbbreviation ?? "").trim();
         const controlledAccess = aApplication?.controlledAccess;
         if (isUndefined(controlledAccess)) {
             console.error(ERROR.APPLICATION_CONTROLLED_ACCESS_NOT_FOUND, ` id=${aApplication?._id}`);
@@ -1410,6 +1414,11 @@ const setDefaultIfNoName = (str) => {
     return (name.length > 0) ? (name) : "NA";
 }
 
+/** Abbreviation for $study-style email slots; falls back to application study name. (Inquire/PV abbrev lines use defaultStudyAbbreviationToNA separately.) */
+function studyLabelForEmailBody(application) {
+    return defaultStudyAbbreviationToStudyName(application?.studyAbbreviation, application?.studyName);
+}
+
 const getCCEmails = (submitterEmail, application) => {
     const questionnaire = getApplicationQuestionnaire(application);
     if (!questionnaire || !submitterEmail) {
@@ -1431,7 +1440,7 @@ const sendEmails = {
                 toBCCEmails, {
                 firstName: applicantName},{
                 pi: `${applicantName}`,
-                study: setDefaultIfNoName(application?.studyAbbreviation),
+                study: studyLabelForEmailBody(application),
                 officialEmail: `${emailParams.officialEmail}.`,
                 inactiveDays: emailParams.inactiveDays,
                 url: emailParams.url
@@ -1477,7 +1486,7 @@ const sendEmails = {
                 [],
                 toBCCEmails, {
                 pi: `${userInfo.firstName} ${userInfo.lastName}${programName === "NA" ? "." : `, and associated with the ${programName} program.`}`,
-                study: application?.studyAbbreviation || "NA",
+                study: studyLabelForEmailBody(application),
                 url: emailParams.url
             });
         }
@@ -1495,7 +1504,7 @@ const sendEmails = {
             const toBCCEmails = getUserEmails(toBCCUsers)
                 ?.filter((email) => !CCEmails.includes(email) && applicantInfo?.email !== email);
             const studyName = setDefaultIfNoName(application?.studyName);
-            const studyAbbreviation = setDefaultIfNoName(application?.studyAbbreviation);
+            const studyAbbreviation = defaultStudyAbbreviationToNA(application?.studyAbbreviation);
             await notificationService.inquireQuestionNotification(application?.applicant?.applicantEmail,
                 CCEmails,
                 toBCCEmails,{
@@ -1520,7 +1529,7 @@ const sendEmails = {
                 firstName: application?.applicant?.applicantName,
                 reviewComments
             }, {
-                study: `${application?.studyAbbreviation},`
+                study: `${studyLabelForEmailBody(application)},`
             });
         }
     }

--- a/services/notify-user.js
+++ b/services/notify-user.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const {createEmailTemplate} = require("../lib/create-email-template");
 const sanitizeHtml = require('sanitize-html');
 const {replaceMessageVariables} = require("../utility/string-util");
+const {defaultStudyAbbreviationToNA} = require("../utility/study-abbrev-helpers");
 const {
     sanitizeAllowlistedHtml,
     PRESET_SR_APPROVAL_PENDING_HTML
@@ -647,7 +648,7 @@ class NotifyUser {
             [SUBMITTER_NAME, templateParams?.submitterName],
             [SUBMITTER_EMAIL, templateParams?.submitterEmail],
             [STUDY_NAME, templateParams?.studyName],
-            [STUDY_ABBREVIATION, templateParams?.studyAbbreviation],
+            [STUDY_ABBREVIATION, defaultStudyAbbreviationToNA(templateParams?.studyAbbreviation)],
             [DATA_SUBMISSION_ID, templateParams?.submissionID],
             [NODE, templateParams?.nodeName],
             [PROPERTY, templateParams?.property],

--- a/test/services/application.test.js
+++ b/test/services/application.test.js
@@ -553,6 +553,29 @@ describe('Application', () => {
             expect(findManyMock).toHaveBeenCalled();
         });
 
+        it('fills studyAbbreviation with studyName in the list response when abbrev is empty', async () => {
+            const row = {
+                id: 'a1',
+                studyName: 'My Full Study',
+                studyAbbreviation: '   ',
+                status: NEW,
+                applicant: { id: 'u1', fullName: 'Alice', email: 'a@a' }
+            };
+            let n = 0;
+            const findManyMock = jest.fn().mockImplementation(() => {
+                n += 1;
+                if (n === 1) {
+                    return Promise.resolve([row]);
+                }
+                return Promise.resolve([]);
+            });
+            app.applicationDAO.findMany = findManyMock;
+            app.applicationDAO.count = jest.fn().mockResolvedValue(1);
+            const result = await app.listApplications({}, context);
+            expect(result.applications[0].studyAbbreviation).toBe('My Full Study');
+            expect(result.applications[0].studyName).toBe('My Full Study');
+        });
+
         it('returns empty list when scope is study (only all and own supported for filters)', async () => {
             mockAuthorizationService.getPermissionScope.mockResolvedValue([{ scope: 'study', scopeValues: ['study1'] }]);
             userScopeMock.isAllScope.mockReturnValue(false);
@@ -1418,6 +1441,52 @@ describe('Application', () => {
             expect(mockApprovedStudiesService.storeApprovedStudies).toHaveBeenCalled();
             const args = mockApprovedStudiesService.storeApprovedStudies.mock.calls[0];
             expect(args[0]).toBeUndefined(); // applicationID should be undefined when no _id
+        });
+
+        it('should pass empty studyAbbreviation to storeApprovedStudies when missing, not questionnaire.study.name', async () => {
+            const aApplication = {
+                _id: 'app1',
+                studyName: 'Study One',
+                studyAbbreviation: '   ',
+                organization: { name: 'Org One' },
+                controlledAccess: true,
+                ORCID: '0000-0001',
+                PI: 'PI Name',
+                openAccess: false,
+                programName: 'Program One',
+            };
+            const questionnaire = {
+                study: { name: 'From Questionnaire Only', dbGaPPPHSNumber: 'phs001234' },
+            };
+            mockApprovedStudiesService.storeApprovedStudies.mockResolvedValue({ _id: 'approvedStudy1' });
+
+            await app._saveApprovedStudies(aApplication, questionnaire, false, undefined, false, null);
+
+            const args = mockApprovedStudiesService.storeApprovedStudies.mock.calls[0];
+            expect(args[2]).toBe('');
+        });
+
+        it('should preserve studyAbbreviation when it matches studyName (user input)', async () => {
+            const aApplication = {
+                _id: 'app1',
+                studyName: 'Short Name',
+                studyAbbreviation: 'Short Name',
+                organization: { name: 'Org One' },
+                controlledAccess: true,
+                ORCID: '0000-0001',
+                PI: 'PI Name',
+                openAccess: false,
+                programName: 'Program One',
+            };
+            const questionnaire = {
+                study: { name: 'Other questionnaire label', dbGaPPPHSNumber: 'phs001234' },
+            };
+            mockApprovedStudiesService.storeApprovedStudies.mockResolvedValue({ _id: 'approvedStudy1' });
+
+            await app._saveApprovedStudies(aApplication, questionnaire, false, undefined, false, null);
+
+            const args = mockApprovedStudiesService.storeApprovedStudies.mock.calls[0];
+            expect(args[2]).toBe('Short Name');
         });
     });
 

--- a/test/utility/data.commons.remapper.test.js
+++ b/test/utility/data.commons.remapper.test.js
@@ -1,5 +1,5 @@
 const {getDataCommonsDisplayName, getDataCommonsDisplayNamesForSubmission, getDataCommonsDisplayNamesForListSubmissions, genericGetDataCommonsDisplayNames,
-    getDataCommonsDisplayNamesForUser
+    getDataCommonsDisplayNamesForUser, applyStudyAbbreviationFallbackToListSubmission
 } = require('../../utility/data-commons-remapper');
 
 describe('Data Commons Remapper Test', () => {
@@ -82,10 +82,23 @@ describe('Data Commons Remapper Test', () => {
         let outputSubmission = {
             dataCommons: "CDS",
             dataCommonsDisplayName: "GC",
+            studyAbbreviation: ""
         }
         inputListSubmission.submissions = [inputSubmission, {}, inputSubmission]
-        outputListSubmission.submissions = [outputSubmission, {}, outputSubmission]
+        outputListSubmission.submissions = [outputSubmission, { studyAbbreviation: "" }, outputSubmission]
         expect(getDataCommonsDisplayNamesForListSubmissions(inputListSubmission)).toStrictEqual(outputListSubmission);
+    });
+
+    test('applyStudyAbbreviationFallbackToListSubmission uses studyName when studyAbbreviation is empty', () => {
+        const row = {
+            dataCommons: "CDS",
+            studyName: "Top level name",
+            studyAbbreviation: "   ",
+            study: { studyName: "Nested name", studyAbbreviation: " \t " }
+        };
+        const out = applyStudyAbbreviationFallbackToListSubmission({ ...row });
+        expect(out.studyAbbreviation).toBe("Top level name");
+        expect(out.study.studyAbbreviation).toBe("Nested name");
     });
 
     test('/test getDataCommonsDisplayNamesForUser', () => {

--- a/test/utility/study-abbrev-helpers.test.js
+++ b/test/utility/study-abbrev-helpers.test.js
@@ -1,0 +1,61 @@
+const {
+    defaultStudyAbbreviationToStudyName,
+    defaultStudyAbbreviationToNA,
+    applyStudyAbbreviationFallbackToListPrograms
+} = require('../../utility/study-abbrev-helpers');
+
+describe('study-abbrev-helpers', () => {
+    describe('defaultStudyAbbreviationToStudyName', () => {
+        it('returns trimmed abbrev when present', () => {
+            expect(defaultStudyAbbreviationToStudyName('  AB  ', 'Full Name')).toBe('AB');
+        });
+        it('returns fullName when abbrev null or empty or whitespace', () => {
+            expect(defaultStudyAbbreviationToStudyName(null, 'Full Study')).toBe('Full Study');
+            expect(defaultStudyAbbreviationToStudyName('', 'Full Study')).toBe('Full Study');
+            expect(defaultStudyAbbreviationToStudyName('  \t ', 'Full Study')).toBe('Full Study');
+        });
+        it('returns empty string when both missing', () => {
+            expect(defaultStudyAbbreviationToStudyName(null, null)).toBe('');
+            expect(defaultStudyAbbreviationToStudyName(' ', '  ')).toBe('');
+        });
+    });
+
+    describe('defaultStudyAbbreviationToNA', () => {
+        it('returns trimmed abbrev when present', () => {
+            expect(defaultStudyAbbreviationToNA('  x  ')).toBe('x');
+        });
+        it('returns NA when null empty or whitespace', () => {
+            expect(defaultStudyAbbreviationToNA(null)).toBe('NA');
+            expect(defaultStudyAbbreviationToNA('')).toBe('NA');
+            expect(defaultStudyAbbreviationToNA('   ')).toBe('NA');
+        });
+    });
+
+    describe('applyStudyAbbreviationFallbackToListPrograms', () => {
+        it('sets studyAbbreviation to studyName per study when abbrev is empty', () => {
+            const input = {
+                total: 1,
+                programs: [
+                    {
+                        _id: 'org1',
+                        name: 'Program 1',
+                        studies: [{ studyName: 'Approved Name', studyAbbreviation: '   ' }]
+                    }
+                ]
+            };
+            const out = applyStudyAbbreviationFallbackToListPrograms(input);
+            expect(out.programs[0].studies[0].studyAbbreviation).toBe('Approved Name');
+        });
+        it('returns the same object reference when there are no programs', () => {
+            const empty = { total: 0, programs: [] };
+            expect(applyStudyAbbreviationFallbackToListPrograms(empty)).toBe(empty);
+        });
+        it('returns the same object reference when programs have no studies arrays', () => {
+            const input = {
+                total: 1,
+                programs: [{ _id: 'org1', name: 'Program 1' }]
+            };
+            expect(applyStudyAbbreviationFallbackToListPrograms(input)).toBe(input);
+        });
+    });
+});

--- a/test/utility/study-abbrev-helpers.test.js
+++ b/test/utility/study-abbrev-helpers.test.js
@@ -57,5 +57,43 @@ describe('study-abbrev-helpers', () => {
             };
             expect(applyStudyAbbreviationFallbackToListPrograms(input)).toBe(input);
         });
+        it('returns the same object reference when every study has a non-empty abbreviation', () => {
+            const input = {
+                total: 1,
+                programs: [
+                    {
+                        _id: 'org1',
+                        name: 'Program 1',
+                        studies: [
+                            { studyName: 'A', studyAbbreviation: 'S1' },
+                            { studyName: 'B', studyAbbreviation: '  x  ' }
+                        ]
+                    }
+                ]
+            };
+            expect(applyStudyAbbreviationFallbackToListPrograms(input)).toBe(input);
+        });
+        it('reuses unchanged program objects when only another program has an empty abbrev', () => {
+            const unchanged = {
+                _id: 'org1',
+                name: 'OK',
+                studies: [{ studyName: 'A', studyAbbreviation: 'AB' }]
+            };
+            const input = {
+                total: 2,
+                programs: [
+                    unchanged,
+                    {
+                        _id: 'org2',
+                        name: 'Needs fix',
+                        studies: [{ studyName: 'B', studyAbbreviation: '   ' }]
+                    }
+                ]
+            };
+            const out = applyStudyAbbreviationFallbackToListPrograms(input);
+            expect(out).not.toBe(input);
+            expect(out.programs[0]).toBe(unchanged);
+            expect(out.programs[1].studies[0].studyAbbreviation).toBe('B');
+        });
     });
 });

--- a/utility/data-commons-remapper.js
+++ b/utility/data-commons-remapper.js
@@ -1,5 +1,6 @@
 const DISPLAY_NAMES_MAP = require("../constants/data-commons-display-names-map");
 const {isTrue} = require("../crdc-datahub-database-drivers/utility/string-utility");
+const {defaultStudyAbbreviationToStudyName} = require("./study-abbrev-helpers");
 
 
 function getDataCommonsDisplayName(datacommons){
@@ -34,12 +35,39 @@ function getDataCommonsDisplayNamesForSubmission(submission){
     return submission;
 }
 
+/**
+ * For listSubmissions only: when studyAbbreviation is empty, expose studyName in its place in the response.
+ * @param {Object} submission list row from DAO (may be mutated)
+ */
+function applyStudyAbbreviationFallbackToListSubmission(submission) {
+    if (!submission) {
+        return submission;
+    }
+    const name = submission.studyName ?? submission.study?.studyName;
+    const resolved = defaultStudyAbbreviationToStudyName(
+        submission.studyAbbreviation ?? submission.study?.studyAbbreviation,
+        name
+    );
+    submission.studyAbbreviation = resolved;
+    if (submission.study) {
+        submission.study = {
+            ...submission.study,
+            studyAbbreviation: defaultStudyAbbreviationToStudyName(
+                submission.study.studyAbbreviation,
+                submission.study.studyName
+            )
+        };
+    }
+    return submission;
+}
+
 function getDataCommonsDisplayNamesForListSubmissions(listSubmissions){
     if (!listSubmissions){
         return null;
     }
     if (listSubmissions.submissions){
         listSubmissions.submissions = genericGetDataCommonsDisplayNames(listSubmissions.submissions, getDataCommonsDisplayNamesForSubmission);
+        listSubmissions.submissions = listSubmissions.submissions.map(applyStudyAbbreviationFallbackToListSubmission);
     }
     if (listSubmissions.dataCommons){
         listSubmissions.dataCommonsDisplayNames = genericGetDataCommonsDisplayNames(listSubmissions.dataCommons, getDataCommonsDisplayName);
@@ -117,6 +145,7 @@ module.exports = {
     genericGetDataCommonsDisplayNames,
     getDataCommonsDisplayNamesForSubmission,
     getDataCommonsDisplayNamesForListSubmissions,
+    applyStudyAbbreviationFallbackToListSubmission,
     getDataCommonsDisplayNamesForUser,
     getDataCommonsDisplayNamesForApprovedStudy,
     getDataCommonsDisplayNamesForApprovedStudyList,

--- a/utility/study-abbrev-helpers.js
+++ b/utility/study-abbrev-helpers.js
@@ -33,31 +33,68 @@ function isStudyAbbreviationEmpty(abbrev) {
 }
 
 /**
- * listPrograms API response only: when each approved study's abbreviation is empty, show studyName in the abbrev field.
+ * Returns true if any approved study has an empty (null/undefined/whitespace-only) studyAbbreviation.
+ * @param {Array} programs
+ */
+function programsHaveAnyEmptyStudyAbbrev(programs) {
+    if (!programs?.length) {
+        return false;
+    }
+    for (const p of programs) {
+        if (!p?.studies?.length) {
+            continue;
+        }
+        for (const s of p.studies) {
+            if (isStudyAbbreviationEmpty(s?.studyAbbreviation)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * listPrograms API response only: when a study's abbreviation is empty, set studyAbbreviation to studyName (trimmed).
+ * Returns the same top-level reference when no program has a study with an empty abbrev; otherwise clones only
+ * programs/studies that need updates.
  * @param {{ total?: number, programs?: Array }} listProgramsResult result of Organization#listPrograms
- * @returns {typeof listProgramsResult} new object if any `studies` were mapped; same reference if no work needed
+ * @returns {typeof listProgramsResult}
  */
 function applyStudyAbbreviationFallbackToListPrograms(listProgramsResult) {
     if (!listProgramsResult?.programs?.length) {
         return listProgramsResult;
     }
-    if (!listProgramsResult.programs.some((p) => p?.studies?.length)) {
+    const programs = listProgramsResult.programs;
+    if (!programsHaveAnyEmptyStudyAbbrev(programs)) {
         return listProgramsResult;
     }
     return {
         ...listProgramsResult,
-        programs: listProgramsResult.programs.map((program) => {
-            if (!program?.studies?.length) {
-                return program;
-            }
-            return {
-                ...program,
-                studies: program.studies.map((s) => ({
-                    ...s,
-                    studyAbbreviation: defaultStudyAbbreviationToStudyName(s.studyAbbreviation, s.studyName)
-                }))
-            };
-        })
+        programs: programs.map((program) => mapProgramStudiesAbbrevFallback(program))
+    };
+}
+
+function mapProgramStudiesAbbrevFallback(program) {
+    if (!program?.studies?.length) {
+        return program;
+    }
+    let changed = false;
+    const studies = program.studies.map((s) => {
+        if (!isStudyAbbreviationEmpty(s?.studyAbbreviation)) {
+            return s;
+        }
+        changed = true;
+        return {
+            ...s,
+            studyAbbreviation: defaultStudyAbbreviationToStudyName(s.studyAbbreviation, s.studyName)
+        };
+    });
+    if (!changed) {
+        return program;
+    }
+    return {
+        ...program,
+        studies
     };
 }
 

--- a/utility/study-abbrev-helpers.js
+++ b/utility/study-abbrev-helpers.js
@@ -1,0 +1,68 @@
+/**
+ * Returns the study abbreviation or the study name if the abbreviation is empty.
+ * Primarily intended for API responses used to get table data.
+ * @param {string} abbrev the study abbreviation
+ * @param {string} fullName the study name
+ * @returns the study abbreviation or the study name if the abbreviation is empty
+ */
+function defaultStudyAbbreviationToStudyName(abbrev, fullName) {
+    let value = isStudyAbbreviationEmpty(abbrev) ? fullName : abbrev;
+    return (value ?? "").toString().trim();
+}
+
+/**
+ * Returns the trimmed study abbreviation, or the literal "NA" if the abbreviation is empty
+ * (null, empty, or whitespace only).
+ * Used for the Inquire SR template's Study Abbreviation line and PV request notifications only;
+ * other emails use defaultStudyAbbreviationToStudyName with the application study name.
+ * @param {string} abbrev the study abbreviation
+ * @returns {string} trimmed abbrev, or "NA" when there is no abbrev
+ */
+function defaultStudyAbbreviationToNA(abbrev) {
+    const value = (abbrev ?? "").toString().trim();
+    return value.length > 0 ? value : "NA";
+}
+
+/**
+ * Checks if the study abbreviation is falsy or whitespace only.
+ * @param {*} abbrev the study abbreviation
+ * @returns true if the abbreviation is empty, false otherwise
+ */
+function isStudyAbbreviationEmpty(abbrev) {
+    return (abbrev ?? "").toString().trim().length === 0;
+}
+
+/**
+ * listPrograms API response only: when each approved study's abbreviation is empty, show studyName in the abbrev field.
+ * @param {{ total?: number, programs?: Array }} listProgramsResult result of Organization#listPrograms
+ * @returns {typeof listProgramsResult} new object if any `studies` were mapped; same reference if no work needed
+ */
+function applyStudyAbbreviationFallbackToListPrograms(listProgramsResult) {
+    if (!listProgramsResult?.programs?.length) {
+        return listProgramsResult;
+    }
+    if (!listProgramsResult.programs.some((p) => p?.studies?.length)) {
+        return listProgramsResult;
+    }
+    return {
+        ...listProgramsResult,
+        programs: listProgramsResult.programs.map((program) => {
+            if (!program?.studies?.length) {
+                return program;
+            }
+            return {
+                ...program,
+                studies: program.studies.map((s) => ({
+                    ...s,
+                    studyAbbreviation: defaultStudyAbbreviationToStudyName(s.studyAbbreviation, s.studyName)
+                }))
+            };
+        })
+    };
+}
+
+module.exports = {
+    defaultStudyAbbreviationToStudyName,
+    defaultStudyAbbreviationToNA,
+    applyStudyAbbreviationFallbackToListPrograms
+};


### PR DESCRIPTION
- Remove the logic to automatically set the study abbreviation equal to the study name in SRF if it is not provided
- Replace empty study abbreviations with the study name for the cases where the study abbreviation is displayed in table data and when used in a sentence in an email
- Replace the empty study abbreviation with NA when study properties are listed in an email