### PR TITLE
3737: Updates after testing

### DIFF
--- a/routers/graphql-router.js
+++ b/routers/graphql-router.js
@@ -28,7 +28,6 @@ const {ApprovedStudiesService} = require("../services/approved-studies");
 const {BatchService, UploadingMonitor} = require("../services/batch-service");
 const {S3Service} = require("../services/s3-service");
 const {Organization} = require("../crdc-datahub-database-drivers/services/organization");
-const {applyStudyAbbreviationFallbackToListPrograms} = require("../utility/study-abbrev-helpers");
 const {DataRecordService} = require("../services/data-record-service");
 const {UtilityService} = require("../services/utility");
 const {InstitutionService} = require("../services/institution-service");
@@ -225,10 +224,7 @@ dbConnector.connect().then(async () => {
         editUser : userService.editUser.bind(userService),
         grantToken : userService.grantToken.bind(userService),
         listActiveDCPs: userService.listActiveDCPsAPI.bind(userService),
-        listPrograms: async (params, context) => {
-            const result = await organizationService.listPrograms(params, context);
-            return applyStudyAbbreviationFallbackToListPrograms(result);
-        },
+        listPrograms: organizationService.listPrograms.bind(organizationService),
         getOrganization : async (params, context) => {
             const userScope = await getOrgUserScope(authorizationService, context?.userInfo, ADMIN.MANAGE_PROGRAMS);
             if (userScope.isNoneScope()) {

--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -32,6 +32,8 @@ const SubmissionDAO = require("../dao/submission");
 const ApplicationDAO = require("../dao/application");
 const {PendingGPA} = require("../domain/pending-gpa");
 const { parseApprovedStudyStatusInput, parseApprovedStudyStatusesFilterInput } = require("../utility/study-utility");
+const { defaultStudyAbbreviationToStudyName } = require("../utility/study-abbrev-helpers");
+
 class ApprovedStudiesService {
     constructor(approvedStudiesCollection, userCollection, organizationService, submissionCollection, authorizationService, notificationsService, emailParams) {
         this.approvedStudiesCollection = approvedStudiesCollection;
@@ -52,7 +54,8 @@ class ApprovedStudiesService {
         const program = await this._validateProgramID(programID);
         const validatedProgramID = program?._id;
 
-        const approvedStudies = ApprovedStudies.createApprovedStudies(applicationID, studyName, studyAbbreviation, dbGaPID, organizationName, controlledAccess, ORCID, PI, openAccess, useProgramPC, pendingModelChange, primaryContactID, pendingGPA, validatedProgramID, pendingImageDeIdentification);
+        const resolvedStudyAbbreviation = defaultStudyAbbreviationToStudyName(studyAbbreviation, studyName);
+        const approvedStudies = ApprovedStudies.createApprovedStudies(applicationID, studyName, resolvedStudyAbbreviation, dbGaPID, organizationName, controlledAccess, ORCID, PI, openAccess, useProgramPC, pendingModelChange, primaryContactID, pendingGPA, validatedProgramID, pendingImageDeIdentification);
         const res = await this.approvedStudyDAO.create(approvedStudies);
 
         if (!res) {
@@ -223,9 +226,7 @@ class ApprovedStudiesService {
             }
         }
 
-        if (!acronym){
-            acronym = name;
-        }
+        acronym = defaultStudyAbbreviationToStudyName(acronym, name);
 
         this._validatePendingGPA(GPAName, controlledAccess, isPendingGPA);
         const pendingGPA = PendingGPA.create(GPAName, isPendingGPA);

--- a/test/services/application.test.js
+++ b/test/services/application.test.js
@@ -203,6 +203,38 @@ describe('Application', () => {
 
             expect(app._checkConditionalApproval).toHaveBeenCalledWith(expect.objectContaining({ _id: 'app1', status: 'approved' }));
         });
+
+        it('does not replace missing or whitespace-only studyAbbreviation with study name', async () => {
+            userScopeMock.isNoneScope.mockReturnValue(false);
+            userScopeMock.isAllScope.mockReturnValue(true);
+            UserScope.create.mockReturnValue(userScopeMock);
+
+            app._getApplicationVersionByStatus = jest.fn().mockResolvedValue('3.0');
+
+            app.getApplicationById = jest.fn().mockResolvedValue({
+                _id: 'app1',
+                status: NEW,
+                studyName: 'Full Study',
+                studyAbbreviation: null,
+                applicant: { applicantID: 'u1', applicantName: 'Submitter', applicantEmail: 's@test.com' }
+            });
+            await expect(app.getApplication({ _id: 'app1' }, context)).resolves.toMatchObject({
+                studyAbbreviation: null,
+                studyName: 'Full Study'
+            });
+
+            app.getApplicationById = jest.fn().mockResolvedValue({
+                _id: 'app1',
+                status: NEW,
+                studyName: 'Full Study',
+                studyAbbreviation: '   ',
+                applicant: { applicantID: 'u1', applicantName: 'Submitter', applicantEmail: 's@test.com' }
+            });
+            await expect(app.getApplication({ _id: 'app1' }, context)).resolves.toMatchObject({
+                studyAbbreviation: '   ',
+                studyName: 'Full Study'
+            });
+        });
     });
 
     describe('_getApplicationVersionByStatus', () => {
@@ -1443,7 +1475,8 @@ describe('Application', () => {
             expect(args[0]).toBeUndefined(); // applicationID should be undefined when no _id
         });
 
-        it('should pass empty studyAbbreviation to storeApprovedStudies when missing, not questionnaire.study.name', async () => {
+        // Application passes the trimmed form field only (no questionnaire fallback). ApprovedStudiesService.storeApprovedStudies persists studyName when abbrev is empty.
+        it('should pass empty trimmed studyAbbreviation from application to storeApprovedStudies, not questionnaire.study.name', async () => {
             const aApplication = {
                 _id: 'app1',
                 studyName: 'Study One',

--- a/test/services/approved-studies.test.js
+++ b/test/services/approved-studies.test.js
@@ -150,6 +150,13 @@ describe('ApprovedStudiesService', () => {
             expect(result).toEqual({_id: 'new-study-id'});
         });
 
+        it('passes trimmed study name as abbreviation when acronym is whitespace-only', async () => {
+            const result = await service.addApprovedStudyAPI({ ...mockParams, acronym: '   \t' }, mockContext);
+            expect(service.storeApprovedStudies).toHaveBeenCalledWith(
+                null, 'New Study', 'New Study', 'phs001234', null, true, '0000-0002-1825-0097', 'Dr. New', false, false, false, 'contact-id', mockGPA, 'org-id', undefined);
+            expect(result).toEqual({ _id: 'new-study-id' });
+        });
+
         it('should pass pendingImageDeIdentification to storeApprovedStudies when provided', async () => {
             const result = await service.addApprovedStudyAPI(
                 { ...mockParams, pendingImageDeIdentification: true },
@@ -1158,6 +1165,26 @@ describe('ApprovedStudiesService', () => {
             expect(service.approvedStudyDAO.create).toHaveBeenCalledWith(fakeStudy);
 
             expect(result).toBe(fakeStudy);
+        });
+
+        it('passes trimmed studyName as studyAbbreviation to createApprovedStudies when abbreviation is null, empty, or whitespace-only', async () => {
+            const validProgramID = 'valid-program-id-123';
+            const validProgram = { _id: validProgramID, name: 'Test Program' };
+            mockOrganizationService.getOrganizationByID.mockResolvedValue(validProgram);
+            ApprovedStudies.createApprovedStudies.mockImplementation((appId, sn, sa, ...rest) => ({ ...fakeStudy, studyName: sn, studyAbbreviation: sa }));
+            service.approvedStudyDAO = {
+                create: jest.fn().mockImplementation((s) => s)
+            };
+
+            for (const emptyAbbrev of [null, '', '  \t  ']) {
+                ApprovedStudies.createApprovedStudies.mockClear();
+                service.approvedStudyDAO.create.mockClear();
+                await service.storeApprovedStudies(
+                    null, '  My Study  ', emptyAbbrev, dbGaPID, organizationName, controlledAccess, ORCID, PI, openAccess,
+                    useProgramPC, pendingModelChange, primaryContactID, null, validProgramID, undefined
+                );
+                expect(ApprovedStudies.createApprovedStudies.mock.calls[0][2]).toBe('My Study');
+            }
         });
 
         it('should pass pendingImageDeIdentification as final argument to createApprovedStudies', async () => {

--- a/test/utility/study-abbrev-helpers.test.js
+++ b/test/utility/study-abbrev-helpers.test.js
@@ -1,7 +1,7 @@
 const {
     defaultStudyAbbreviationToStudyName,
     defaultStudyAbbreviationToNA,
-    applyStudyAbbreviationFallbackToListPrograms
+    isStudyAbbreviationEmpty
 } = require('../../utility/study-abbrev-helpers');
 
 describe('study-abbrev-helpers', () => {
@@ -31,69 +31,16 @@ describe('study-abbrev-helpers', () => {
         });
     });
 
-    describe('applyStudyAbbreviationFallbackToListPrograms', () => {
-        it('sets studyAbbreviation to studyName per study when abbrev is empty', () => {
-            const input = {
-                total: 1,
-                programs: [
-                    {
-                        _id: 'org1',
-                        name: 'Program 1',
-                        studies: [{ studyName: 'Approved Name', studyAbbreviation: '   ' }]
-                    }
-                ]
-            };
-            const out = applyStudyAbbreviationFallbackToListPrograms(input);
-            expect(out.programs[0].studies[0].studyAbbreviation).toBe('Approved Name');
+    describe('isStudyAbbreviationEmpty', () => {
+        it('returns true for null, undefined, empty, or whitespace-only', () => {
+            expect(isStudyAbbreviationEmpty(null)).toBe(true);
+            expect(isStudyAbbreviationEmpty(undefined)).toBe(true);
+            expect(isStudyAbbreviationEmpty('')).toBe(true);
+            expect(isStudyAbbreviationEmpty('   \t')).toBe(true);
         });
-        it('returns the same object reference when there are no programs', () => {
-            const empty = { total: 0, programs: [] };
-            expect(applyStudyAbbreviationFallbackToListPrograms(empty)).toBe(empty);
-        });
-        it('returns the same object reference when programs have no studies arrays', () => {
-            const input = {
-                total: 1,
-                programs: [{ _id: 'org1', name: 'Program 1' }]
-            };
-            expect(applyStudyAbbreviationFallbackToListPrograms(input)).toBe(input);
-        });
-        it('returns the same object reference when every study has a non-empty abbreviation', () => {
-            const input = {
-                total: 1,
-                programs: [
-                    {
-                        _id: 'org1',
-                        name: 'Program 1',
-                        studies: [
-                            { studyName: 'A', studyAbbreviation: 'S1' },
-                            { studyName: 'B', studyAbbreviation: '  x  ' }
-                        ]
-                    }
-                ]
-            };
-            expect(applyStudyAbbreviationFallbackToListPrograms(input)).toBe(input);
-        });
-        it('reuses unchanged program objects when only another program has an empty abbrev', () => {
-            const unchanged = {
-                _id: 'org1',
-                name: 'OK',
-                studies: [{ studyName: 'A', studyAbbreviation: 'AB' }]
-            };
-            const input = {
-                total: 2,
-                programs: [
-                    unchanged,
-                    {
-                        _id: 'org2',
-                        name: 'Needs fix',
-                        studies: [{ studyName: 'B', studyAbbreviation: '   ' }]
-                    }
-                ]
-            };
-            const out = applyStudyAbbreviationFallbackToListPrograms(input);
-            expect(out).not.toBe(input);
-            expect(out.programs[0]).toBe(unchanged);
-            expect(out.programs[1].studies[0].studyAbbreviation).toBe('B');
+        it('returns false when abbrev has non-whitespace content', () => {
+            expect(isStudyAbbreviationEmpty('A')).toBe(false);
+            expect(isStudyAbbreviationEmpty('  x  ')).toBe(false);
         });
     });
 });

--- a/utility/study-abbrev-helpers.js
+++ b/utility/study-abbrev-helpers.js
@@ -32,74 +32,8 @@ function isStudyAbbreviationEmpty(abbrev) {
     return (abbrev ?? "").toString().trim().length === 0;
 }
 
-/**
- * Returns true if any approved study has an empty (null/undefined/whitespace-only) studyAbbreviation.
- * @param {Array} programs
- */
-function programsHaveAnyEmptyStudyAbbrev(programs) {
-    if (!programs?.length) {
-        return false;
-    }
-    for (const p of programs) {
-        if (!p?.studies?.length) {
-            continue;
-        }
-        for (const s of p.studies) {
-            if (isStudyAbbreviationEmpty(s?.studyAbbreviation)) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-/**
- * listPrograms API response only: when a study's abbreviation is empty, set studyAbbreviation to studyName (trimmed).
- * Returns the same top-level reference when no program has a study with an empty abbrev; otherwise clones only
- * programs/studies that need updates.
- * @param {{ total?: number, programs?: Array }} listProgramsResult result of Organization#listPrograms
- * @returns {typeof listProgramsResult}
- */
-function applyStudyAbbreviationFallbackToListPrograms(listProgramsResult) {
-    if (!listProgramsResult?.programs?.length) {
-        return listProgramsResult;
-    }
-    const programs = listProgramsResult.programs;
-    if (!programsHaveAnyEmptyStudyAbbrev(programs)) {
-        return listProgramsResult;
-    }
-    return {
-        ...listProgramsResult,
-        programs: programs.map((program) => mapProgramStudiesAbbrevFallback(program))
-    };
-}
-
-function mapProgramStudiesAbbrevFallback(program) {
-    if (!program?.studies?.length) {
-        return program;
-    }
-    let changed = false;
-    const studies = program.studies.map((s) => {
-        if (!isStudyAbbreviationEmpty(s?.studyAbbreviation)) {
-            return s;
-        }
-        changed = true;
-        return {
-            ...s,
-            studyAbbreviation: defaultStudyAbbreviationToStudyName(s.studyAbbreviation, s.studyName)
-        };
-    });
-    if (!changed) {
-        return program;
-    }
-    return {
-        ...program,
-        studies
-    };
-}
-
 module.exports = {
     defaultStudyAbbreviationToStudyName,
     defaultStudyAbbreviationToNA,
-    applyStudyAbbreviationFallbackToListPrograms
+    isStudyAbbreviationEmpty
 };


### PR DESCRIPTION
- remove missing study abbreviation mapping from listPrograms (not necessary)
- removed applyStudyAbbreviationFallbackToListPrograms
- revert change that removed using study name as the default study abbreviation when it was not provided