### PR TITLE
3647: escape literals in search

### DIFF
--- a/dao/approvedStudy.js
+++ b/dao/approvedStudy.js
@@ -5,7 +5,7 @@ const {ORGANIZATION_COLLECTION, USER_COLLECTION} = require("../crdc-datahub-data
 const ERROR = require("../constants/error-constants");
 const {MongoPagination} = require("../crdc-datahub-database-drivers/domain/mongo-pagination");
 const {DIRECTION, SORT} = require("../crdc-datahub-database-drivers/constants/monogodb-constants");
-const {sanitizeMongoDBInput} = require("../utility/string-util");
+const {sanitizeMongoDBInput, escapeRegexLiteral} = require("../utility/string-util");
 
 const CONTROLLED_ACCESS_ALL = "All";
 const CONTROLLED_ACCESS_OPEN = "Open";
@@ -40,7 +40,7 @@ class ApprovedStudyDAO extends GenericDAO  {
         let matches = {};
         const study = sanitizeMongoDBInput(studyName);
         if (study)
-            matches.$or = [{studyName: {$regex: study, $options: 'i'}}, {studyAbbreviation: {$regex: study, $options: 'i'}}];
+            matches.$or = [{studyName: {$regex: escapeRegexLiteral(study), $options: 'i'}}, {studyAbbreviation: {$regex: escapeRegexLiteral(study), $options: 'i'}}];
         if (controlledAccess) {
             if (!CONTROLLED_ACCESS_OPTIONS.includes(controlledAccess)) {
                 throw new Error(ERROR.INVALID_CONTROLLED_ACCESS);
@@ -59,7 +59,7 @@ class ApprovedStudyDAO extends GenericDAO  {
         }
         const dbGaPID = sanitizeMongoDBInput(dbGaPIDInput);
         if (dbGaPID) {
-            matches.dbGaPID = {$regex: dbGaPID, $options: 'i'};
+            matches.dbGaPID = {$regex: escapeRegexLiteral(dbGaPID), $options: 'i'};
         }
 
         if (programID && programID !== this._ALL) {

--- a/dao/institution.js
+++ b/dao/institution.js
@@ -5,7 +5,7 @@ const { MODEL_NAME} = require('../constants/db-constants');
 const GenericDAO = require("./generic");
 const {USER_COLLECTION} = require("../crdc-datahub-database-drivers/database-constants");
 const {MongoPagination} = require("../crdc-datahub-database-drivers/domain/mongo-pagination");
-const {sanitizeMongoDBInput} = require("../utility/string-util");
+const {sanitizeMongoDBInput, escapeRegexLiteral} = require("../utility/string-util");
 const ROLES = USER_CONSTANTS.USER.ROLES;
 class InstitutionDAO extends GenericDAO {
     _NAME = "name";
@@ -60,7 +60,7 @@ class InstitutionDAO extends GenericDAO {
     _listConditions(institutionNameInput, status){
         const institutionName = sanitizeMongoDBInput(institutionNameInput);
         const validStatus = [INSTITUTION.STATUSES.INACTIVE, INSTITUTION.STATUSES.ACTIVE];
-        const nameCondition = institutionName ? {name: { $regex: institutionName?.trim().replace(/\\/g, "\\\\"), $options: "i" }} : {};
+        const nameCondition = institutionName ? {name: { $regex: escapeRegexLiteral(institutionName.trim()), $options: "i" }} : {};
         const statusCondition = status && status !== this._ALL_FILTER ?
             { status: { $in: [status] || [] } } : { status: { $in: validStatus } };
         return {...nameCondition , ...statusCondition}

--- a/dao/submission.js
+++ b/dao/submission.js
@@ -6,7 +6,7 @@ const {DELETED, CANCELED, NEW, IN_PROGRESS, SUBMITTED, WITHDRAWN, RELEASED, REJE
     COLLABORATOR_PERMISSIONS
 } = require("../constants/submission-constants");
 const ERROR = require("../constants/error-constants");
-const {replaceErrorString} = require("../utility/string-util");
+const {replaceErrorString, escapeRegexLiteral} = require("../utility/string-util");
 const {formatNestedOrganization, formatNestedOrganizations} = require("../utility/organization-transformer");
 const prisma = require("../prisma");
 const { isAllStudy } = require("../utility/study-utility");
@@ -334,13 +334,17 @@ class SubmissionDAO extends GenericDAO {
         // Add filter for submission name if specified
         // This filter is a regex search on the submission name (case-insensitive)
         if (submissionName) {
-            baseConditions.name = {
-                contains: submissionName.trim().replace(/\\/g, ''),
-                mode: 'insensitive'
-            };
+            const submissionNameRaw = submissionName.trim().replace(/\\/g, '');
+            if (submissionNameRaw) {
+                baseConditions.name = {
+                    contains: escapeRegexLiteral(submissionNameRaw),
+                    mode: 'insensitive'
+                };
+            }
         }
         // Add filter for dbGaPID if specified: free-text search over related study's name, abbreviation, or dbGaPID
-        const sanitizedStudySearchTerm = (dbGaPID || '').trim().replace(/\\/g, '');
+        const dbGaPIDRaw = (dbGaPID || '').trim().replace(/\\/g, '');
+        const sanitizedStudySearchTerm = dbGaPIDRaw ? escapeRegexLiteral(dbGaPIDRaw) : '';
         if (sanitizedStudySearchTerm) {
             const studySearchCondition = {
                 OR: [

--- a/services/application.js
+++ b/services/application.js
@@ -10,7 +10,7 @@ const USER_CONSTANTS = require("../crdc-datahub-database-drivers/constants/user-
 const {CreateApplicationEvent, UpdateApplicationStateEvent} = require("../crdc-datahub-database-drivers/domain/log-events");
 const ROLES = USER_CONSTANTS.USER.ROLES;
 const {parseJsonString, isTrue} = require("../crdc-datahub-database-drivers/utility/string-utility");
-const {isUndefined, replaceErrorString} = require("../utility/string-util");
+const {isUndefined, replaceErrorString, escapeRegexLiteral} = require("../utility/string-util");
 const {defaultStudyAbbreviationToStudyName, defaultStudyAbbreviationToNA} = require("../utility/study-abbrev-helpers");
 const {EMAIL_NOTIFICATIONS} = require("../crdc-datahub-database-drivers/constants/user-permission-constants");
 const USER_PERMISSION_CONSTANTS = require("../crdc-datahub-database-drivers/constants/user-permission-constants");
@@ -349,7 +349,7 @@ class Application {
         if (submitterName != null && submitterName !== this._ALL_FILTER) {
             return {applicant: {
                 is: {
-                    fullName: {contains: submitterName.trim().replace(/\\/g, "\\\\"), mode: "insensitive"}
+                    fullName: {contains: escapeRegexLiteral(submitterName.trim()), mode: "insensitive"}
                 }
             }}
         }
@@ -467,7 +467,7 @@ class Application {
         const hasStudyFilter = studySearchTerm?.length > 0 && params.studyName !== this._ALL_FILTER;
         let studyCondition = {};
         if (hasStudyFilter) {
-            const studySearchTermSanitized = studySearchTerm.replace(/\\/g, "\\\\");
+            const studySearchTermSanitized = escapeRegexLiteral(studySearchTerm);
             const containsOption = { contains: studySearchTermSanitized, mode: "insensitive" };
             studyCondition = {
                 OR: [

--- a/services/approved-studies.js
+++ b/services/approved-studies.js
@@ -20,7 +20,7 @@ const {getDataCommonsDisplayNamesForApprovedStudy, getDataCommonsDisplayNamesFor
 } = require("../utility/data-commons-remapper");
 const {SORT: PRISMA_SORT} = require("../constants/db-constants");
 const {UserScope} = require("../domain/user-scope");
-const {replaceErrorString} = require("../utility/string-util");
+const {replaceErrorString, escapeRegexLiteral} = require("../utility/string-util");
 const NA_PROGRAM = "NA";
 const NA = "NA";
 const prisma = require("../prisma");
@@ -67,6 +67,7 @@ class ApprovedStudiesService {
     /**
      * List Approved Studies by a studyName API.
      * Case-insensitive match on studyName (Prisma Mongo `equals` + `mode: insensitive`).
+     * On MongoDB, Prisma implements that filter with a regex; `escapeRegexLiteral` keeps user input literal (e.g. `*`).
      * @api
      * @param {string} studyName
      * @returns {Promise<Object[]>} At most one approved study (same shape as legacy aggregate: array with `_id`)
@@ -79,7 +80,8 @@ class ApprovedStudiesService {
         const row = await prisma.approvedStudy.findFirst({
             where: {
                 studyName: {
-                    equals: trimmed,
+                    // Prisma-on-Mongo compiles insensitive `equals` to regex; escape so metacharacters are literals, not syntax.
+                    equals: escapeRegexLiteral(trimmed),
                     mode: "insensitive"
                 }
             }

--- a/services/release-service.js
+++ b/services/release-service.js
@@ -3,7 +3,7 @@ const path = require('path');
 const {verifySession} = require("../verifier/user-info-verifier");
 const USER_PERMISSION_CONSTANTS = require("../crdc-datahub-database-drivers/constants/user-permission-constants");
 const {UserScope} = require("../domain/user-scope");
-const {replaceErrorString, sanitizeMongoDBInput} = require("../utility/string-util");
+const {replaceErrorString, sanitizeMongoDBInput, escapeRegexLiteral} = require("../utility/string-util");
 const ERROR = require("../constants/error-constants");
 const {MongoPagination} = require("../crdc-datahub-database-drivers/domain/mongo-pagination");
 const {getDataCommonsDisplayName, getDataCommonsOrigin} = require("../utility/data-commons-remapper");
@@ -768,16 +768,17 @@ class ReleaseService {
             { dataCommons: { $in: dataCommonsParams || [] } } : {};
 
         const studyName = sanitizeMongoDBInput(studyInput);
+        const studyRegex = studyName ? escapeRegexLiteral(studyName.trim()) : "";
         const nameCondition = studyName
             ? {
                 $or: [
-                    { studyName: { $regex: studyName.trim().replace(/\\/g, "\\\\"), $options: "i" } },
-                    { studyAbbreviation: { $regex: studyName.trim().replace(/\\/g, "\\\\"), $options: "i" } },
+                    { studyName: { $regex: studyRegex, $options: "i" } },
+                    { studyAbbreviation: { $regex: studyRegex, $options: "i" } },
                 ],
             }
             : {};
         const dbGaPID = sanitizeMongoDBInput(dbGaPIDInput);
-        const dbGaPIDCondition = dbGaPID ? {dbGaPID: { $regex: dbGaPID?.trim().replace(/\\/g, "\\\\"), $options: "i" }} : {};
+        const dbGaPIDCondition = dbGaPID ? {dbGaPID: { $regex: escapeRegexLiteral(dbGaPID.trim()), $options: "i" }} : {};
 
         const baseConditions = {...nameCondition,
             ...dbGaPIDCondition, ...dataCommonsCondition };

--- a/services/submission.js
+++ b/services/submission.js
@@ -23,7 +23,7 @@ const NA = "NA"
 const config = require("../config");
 const ERRORS = require("../constants/error-constants");
 const {ValidationHandler} = require("../utility/validation-handler");
-const {isUndefined, replaceErrorString, isValidFileExtension, fileSizeFormatter} = require("../utility/string-util");
+const {isUndefined, replaceErrorString, isValidFileExtension, fileSizeFormatter, escapeRegexLiteral} = require("../utility/string-util");
 const {NODE_RELATION_TYPES} = require("./data-record-service");
 const {verifyToken} = require("../verifier/token-verifier");
 const {MongoPagination} = require("../crdc-datahub-database-drivers/domain/mongo-pagination");
@@ -1015,7 +1015,7 @@ class Submission {
                 submissionID,
                 nodeType,
                 ...(status !== ALL_FILTER && { status }),
-                ...(nodeID && { nodeID: new RegExp(nodeID, "i") })
+                ...(nodeID && { nodeID: new RegExp(escapeRegexLiteral(nodeID), "i") })
             };
 
             // Data View `properties`: page-local keys from _processSubmissionNodes, plus

--- a/test/dao/dao.approvedStudy.listApprovedStudies.test.js
+++ b/test/dao/dao.approvedStudy.listApprovedStudies.test.js
@@ -169,6 +169,27 @@ describe('ApprovedStudyDAO - listApprovedStudies', () => {
             });
         });
 
+        it('escapes regex metacharacters in study and dbGaPID filters so invalid patterns are not passed to MongoDB', async () => {
+            const mockResult = [{ total: 1, results: [] }];
+            mockCollection.aggregate.mockResolvedValue(mockResult);
+
+            await dao.listApprovedStudies(
+                '***', null, '*', null, null, 10, 0, 'studyName', 'asc'
+            );
+
+            const pipeline = mockCollection.aggregate.mock.calls[0][0];
+            const matchStage = pipeline.find(stage => stage.$match);
+
+            expect(matchStage.$match.$or).toEqual([
+                { studyName: { $regex: '\\*\\*\\*', $options: 'i' } },
+                { studyAbbreviation: { $regex: '\\*\\*\\*', $options: 'i' } }
+            ]);
+            expect(matchStage.$match.dbGaPID).toEqual({
+                $regex: '\\*',
+                $options: 'i'
+            });
+        });
+
         it('should apply programID filter when not "All"', async () => {
             const mockResult = [{ total: 1, results: [] }];
             mockCollection.aggregate.mockResolvedValue(mockResult);

--- a/test/dao/dao.submission.test.js
+++ b/test/dao/dao.submission.test.js
@@ -291,6 +291,23 @@ describe('SubmissionDAO', () => {
                 );
             });
 
+            it('should escape regex metacharacters in name and study search terms', async () => {
+                await dao.listSubmissions(mockUserInfo, mockUserScope, {
+                    ...mockParams,
+                    name: '***',
+                    dbGaPID: '*'
+                });
+
+                const call = prisma.submission.findMany.mock.calls[0][0];
+                expect(call.where.name).toEqual({
+                    contains: '\\*\\*\\*',
+                    mode: 'insensitive'
+                });
+                const andConditions = call.where.AND || [];
+                const dbGaPIDOrCondition = andConditions.find(c => c.OR && c.OR.some(o => o.study?.is));
+                expect(dbGaPIDOrCondition.OR[0].study.is.studyName.contains).toBe('\\*');
+            });
+
             it('should apply dbGaPID filter with case-insensitive search over study name, abbreviation, and dbGaPID', async () => {
                 const paramsWithDbGaPID = { ...mockParams, dbGaPID: 'phs001234' };
 

--- a/test/services/application.test.js
+++ b/test/services/application.test.js
@@ -815,6 +815,16 @@ describe('Application', () => {
                 expect(filter.OR[1].studyAbbreviation).toEqual({ contains: 'aBc', mode: 'insensitive' });
             });
 
+            it('escapes regex metacharacters in studyName search term', async () => {
+                const findManyMock = jest.fn().mockResolvedValue([]);
+                app.applicationDAO.findMany = findManyMock;
+                app.applicationDAO.count = jest.fn().mockResolvedValue(0);
+                await app.listApplications({ studyName: '***' }, context);
+                const filter = findManyMock.mock.calls[0][0];
+                expect(filter.OR[0].studyName).toEqual({ contains: '\\*\\*\\*', mode: 'insensitive' });
+                expect(filter.OR[1].studyAbbreviation).toEqual({ contains: '\\*\\*\\*', mode: 'insensitive' });
+            });
+
             it('does not add study filter when studyName is All', async () => {
                 const findManyMock = jest.fn().mockResolvedValue([]);
                 app.applicationDAO.findMany = findManyMock;

--- a/test/services/submission.processSubmissionNodes.data-view.test.js
+++ b/test/services/submission.processSubmissionNodes.data-view.test.js
@@ -267,6 +267,31 @@ describe('Submission listSubmissionNodes (Data View, paginated path)', () => {
     ]);
   });
 
+  it('uses a safe RegExp for nodeID when the search term contains regex metacharacters', async () => {
+    submissionService.dataRecordDAO.getSubmissionNodes = jest.fn().mockResolvedValue({ total: 0, results: [] });
+    submissionService.dataRecordDAO.getDistinctParentRelationshipKeys = jest.fn().mockResolvedValue([]);
+    submissionService.dataRecordDAO.getDistinctPropsTopLevelKeys = jest.fn().mockResolvedValue([]);
+
+    await submissionService.listSubmissionNodes(
+      {
+        submissionID: 'sub-1',
+        nodeType: 'study_diagnosis',
+        status: 'All',
+        nodeID: '*',
+        first: 10,
+        offset: 0,
+        orderBy: 'nodeID',
+        sortDirection: 'ASC'
+      },
+      { userInfo: { _id: 'u1' } }
+    );
+
+    const queryArg = submissionService.dataRecordDAO.getSubmissionNodes.mock.calls[0][6];
+    expect(queryArg.nodeID).toBeInstanceOf(RegExp);
+    expect(queryArg.nodeID.source).toBe('\\*');
+    expect(queryArg.nodeID.flags).toBe('i');
+  });
+
   it('includes top-level props keys from getDistinctPropsTopLevelKeys when absent on the current page', async () => {
     submissionService.dataRecordDAO.getSubmissionNodes = jest.fn().mockResolvedValue({
       total: 200,

--- a/test/utility/string-util.test.js
+++ b/test/utility/string-util.test.js
@@ -1,0 +1,28 @@
+const { escapeRegexLiteral, sanitizeMongoDBInput } = require('../../utility/string-util');
+
+describe('escapeRegexLiteral', () => {
+    it('escapes regex metacharacters for literal substring match', () => {
+        expect(escapeRegexLiteral('*')).toBe('\\*');
+        expect(escapeRegexLiteral('***')).toBe('\\*\\*\\*');
+        expect(escapeRegexLiteral('foo*bar')).toBe('foo\\*bar');
+        expect(escapeRegexLiteral('a+b')).toBe('a\\+b');
+        expect(escapeRegexLiteral('(test)')).toBe('\\(test\\)');
+    });
+
+    it('leaves alphanumeric text unchanged', () => {
+        expect(escapeRegexLiteral('phs001234')).toBe('phs001234');
+        expect(escapeRegexLiteral('test study')).toBe('test study');
+    });
+
+    it('handles null and undefined', () => {
+        expect(escapeRegexLiteral(null)).toBe('');
+        expect(escapeRegexLiteral(undefined)).toBe('');
+    });
+});
+
+describe('sanitizeMongoDBInput', () => {
+    it('still trims and handles dot-only input', () => {
+        expect(sanitizeMongoDBInput('  x  ')).toBe('x');
+        expect(sanitizeMongoDBInput('...')).toBe("''");
+    });
+});

--- a/utility/string-util.js
+++ b/utility/string-util.js
@@ -31,6 +31,12 @@ const sanitizeMongoDBInput = (raw) => {
     return raw.trim();
 }
 
+/** Escape a string for use as a literal inside MongoDB $regex or Prisma MongoDB case-insensitive filters (which compile to regex). */
+const escapeRegexLiteral = (raw) => {
+    if (raw === undefined || raw === null) return "";
+    return String(raw).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+};
+
 
 const getUniqueArr = (arr) => {return (arr) ? arr.filter((v, i, a) => a.indexOf(v) === i) : []};
 
@@ -165,5 +171,6 @@ module.exports = {
     isValidFileExtension,
     fileSizeFormatter,
     getFormatDateStr,
-    sanitizeMongoDBInput
+    sanitizeMongoDBInput,
+    escapeRegexLiteral
 }


### PR DESCRIPTION
- created a function to escape regex operators in search inputs so that they are treated as literals. These regex operators where causing parsing errors in the MongoDB queries
- used this escapeRegexLiteral in all queries where the user provides text as a search input
- updated unit tests accordingly