### PR TITLE
CRDCDH-3737 Fix `isEmptyApplication` determination logic

### DIFF
--- a/services/utility.js
+++ b/services/utility.js
@@ -34,8 +34,6 @@ class UtilityService {
             !aApplication?.programName &&
             !aApplication?.studyAbbreviation &&
             !aApplication?.studyName &&
-            !aApplication?.ORCID &&
-            !aApplication?.PI &&
             !aApplication?.programAbbreviation &&
             !aApplication?.programDescription
         );

--- a/test/utility/utility.service.test.js
+++ b/test/utility/utility.service.test.js
@@ -1,0 +1,34 @@
+const { UtilityService } = require('../../services/utility');
+
+describe('UtilityService', () => {
+  let utilityService;
+
+  beforeEach(() => {
+    utilityService = new UtilityService();
+  });
+
+  it('should treat an application with only ORCID and PI fields as empty', () => {
+    const result = utilityService.isEmptyApplication({
+      ORCID: '0000-0002-1825-0097',
+      PI: 'Jane Doe'
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should treat an application with a tracked field as non-empty', () => {
+    const result = utilityService.isEmptyApplication({
+      studyName: 'Example Study',
+      ORCID: '0000-0002-1825-0097',
+      PI: 'Jane Doe'
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should treat an entirely empty application as empty', () => {
+    const result = utilityService.isEmptyApplication({});
+
+    expect(result).toBe(true);
+  });
+});

--- a/test/utility/utility.service.test.js
+++ b/test/utility/utility.service.test.js
@@ -1,5 +1,13 @@
 const { UtilityService } = require('../../services/utility');
 
+const CORE_FIELDS = [
+  'programName',
+  'studyAbbreviation',
+  'studyName',
+  'programAbbreviation',
+  'programDescription'
+];
+
 describe('UtilityService', () => {
   let utilityService;
 
@@ -7,28 +15,49 @@ describe('UtilityService', () => {
     utilityService = new UtilityService();
   });
 
-  it('should treat an application with only ORCID and PI fields as empty', () => {
+  it('should be empty when no tracked fields present', () => {
+    expect(utilityService.isEmptyApplication({})).toBe(true);
+  });
+
+  it('should treat ORCID/PI only as empty', () => {
     const result = utilityService.isEmptyApplication({
       ORCID: '0000-0002-1825-0097',
       PI: 'Jane Doe'
     });
-
     expect(result).toBe(true);
   });
 
-  it('should treat an application with a tracked field as non-empty', () => {
-    const result = utilityService.isEmptyApplication({
-      studyName: 'Example Study',
-      ORCID: '0000-0002-1825-0097',
-      PI: 'Jane Doe'
-    });
-
-    expect(result).toBe(false);
+  it.each(CORE_FIELDS)('should treat field %s present as non-empty', (field) => {
+    const app = {};
+    app[field] = 'some value';
+    expect(utilityService.isEmptyApplication(app)).toBe(false);
   });
 
-  it('should treat an entirely empty application as empty', () => {
-    const result = utilityService.isEmptyApplication({});
+  it.each(CORE_FIELDS)('should treat field %s with null/undefined/empty-string as empty', (field) => {
+    const appNull = {};
+    appNull[field] = null;
+    expect(utilityService.isEmptyApplication(appNull)).toBe(true);
 
-    expect(result).toBe(true);
+    const appUndef = {};
+    appUndef[field] = undefined;
+    expect(utilityService.isEmptyApplication(appUndef)).toBe(true);
+
+    const appEmpty = {};
+    appEmpty[field] = '';
+    expect(utilityService.isEmptyApplication(appEmpty)).toBe(true);
+  });
+
+  it('should consider whitespace-only value as non-empty by current logic', () => {
+    const app = { studyName: '   ' };
+    expect(utilityService.isEmptyApplication(app)).toBe(false);
+  });
+
+  it('should be non-empty when multiple core fields present', () => {
+    const app = { programName: 'P', programDescription: 'D' };
+    expect(utilityService.isEmptyApplication(app)).toBe(false);
+  });
+
+  it('should be empty when all core fields absent', () => {
+    expect(utilityService.isEmptyApplication({ ORCID: 'x', PI: 'y' })).toBe(true);
   });
 });


### PR DESCRIPTION
### Overview

This PR introduces a fix for how we determine if a SRF qualifies as "New" by changing the isEmptyApplication utility logic to remove the autofilled fields:

- PI
- ORCID

Since these fields are autofilled by the frontend, they do not change the status of the SRF to "In Progress".

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-3737 (Bug)