### PR TITLE
3738: Include study in email when NA

### DIFF
--- a/services/application.js
+++ b/services/application.js
@@ -1462,7 +1462,15 @@ const setDefaultIfNoName = (str) => {
     return (name.length > 0) ? (name) : "NA";
 }
 
-/** Abbreviation for $study-style email slots; falls back to application study name. (Inquire/PV abbrev lines use defaultStudyAbbreviationToNA separately.) */
+/**
+ * Label for `$study`-style message variables and notification template `studyName`.
+ * First resolves via `defaultStudyAbbreviationToStudyName` (trimmed abbreviation if non-empty,
+ * otherwise trimmed `studyName`). Then `setDefaultIfNoName` maps empty or whitespace-only results
+ * to the literal string `NA`, so callers and templates always get a non-empty value (e.g. blank
+ * New submission requests). Inquire/PV Study Abbreviation lines use `defaultStudyAbbreviationToNA` separately.
+ * @param {{ studyAbbreviation?: string, studyName?: string }} [application]
+ * @returns {string} Resolved abbreviation or study name, or `NA`
+ */
 function studyLabelForEmailBody(application) {
     const label = defaultStudyAbbreviationToStudyName(application?.studyAbbreviation, application?.studyName);
     return setDefaultIfNoName(label);

--- a/services/application.js
+++ b/services/application.js
@@ -1464,7 +1464,8 @@ const setDefaultIfNoName = (str) => {
 
 /** Abbreviation for $study-style email slots; falls back to application study name. (Inquire/PV abbrev lines use defaultStudyAbbreviationToNA separately.) */
 function studyLabelForEmailBody(application) {
-    return defaultStudyAbbreviationToStudyName(application?.studyAbbreviation, application?.studyName);
+    const label = defaultStudyAbbreviationToStudyName(application?.studyAbbreviation, application?.studyName);
+    return setDefaultIfNoName(label);
 }
 
 const getCCEmails = (submitterEmail, application) => {
@@ -1480,15 +1481,18 @@ const getCCEmails = (submitterEmail, application) => {
 const sendEmails = {
     inactiveApplications: async (notificationService, emailParams, email, applicantName, application, BCCEmails) => {
         try {
+            const studyLabel = studyLabelForEmailBody(application);
             const CCEmails = getCCEmails(email, application);
             const toBCCEmails = BCCEmails
                 ?.filter((BCCEmail) => !CCEmails.includes(BCCEmail) && BCCEmail !== email);
             await notificationService.inactiveApplicationsNotification(email,
                 CCEmails,
                 toBCCEmails, {
-                firstName: applicantName},{
+                firstName: applicantName,
+                studyName: studyLabel
+            },{
                 pi: `${applicantName}`,
-                study: studyLabelForEmailBody(application),
+                study: studyLabel,
                 officialEmail: `${emailParams.officialEmail}.`,
                 inactiveDays: emailParams.inactiveDays,
                 url: emailParams.url

--- a/test/services/application.deleteInactiveApplications.test.js
+++ b/test/services/application.deleteInactiveApplications.test.js
@@ -282,6 +282,59 @@ describe('deleteInactiveApplications Error Handling', () => {
             }
         });
 
+        test('inactiveApplicationsNotification receives studyName and study NA for blank New SRF', async () => {
+            const mockShortApps = [
+                {
+                    _id: 'app2',
+                    applicantID: 'user2',
+                    applicant: { applicantEmail: 'user2@test.com', applicantName: 'User 2' },
+                    questionnaireData: '{}',
+                    studyAbbreviation: undefined,
+                    studyName: undefined,
+                    programName: undefined,
+                    status: 'New',
+                    ORCID: undefined,
+                    PI: undefined,
+                    programAbbreviation: undefined,
+                    programDescription: undefined,
+                    history: [],
+                    updatedAt: new Date('2023-01-01')
+                }
+            ];
+
+            mockApplicationDAO.getInactiveApplication
+                .mockResolvedValueOnce([]) // default window
+                .mockResolvedValueOnce(mockShortApps); // short window
+            mockUserService.getUsersByNotifications.mockResolvedValue([]);
+            mockUserService.userCollection.aggregate.mockResolvedValue([
+                { _id: 'user2', notifications: ['submission_request:deleted'] }
+            ]);
+            mockApplicationDAO.delete.mockResolvedValue({});
+
+            const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+            try {
+                await applicationService.deleteInactiveApplications();
+
+                expect(mockNotificationsService.inactiveApplicationsNotification).toHaveBeenCalledWith(
+                    'user2@test.com',
+                    [],
+                    [],
+                    expect.objectContaining({
+                        firstName: 'User 2',
+                        studyName: 'NA'
+                    }),
+                    expect.objectContaining({
+                        study: 'NA',
+                        inactiveDays: 30,
+                        url: 'http://test.com'
+                    })
+                );
+            } finally {
+                consoleSpy.mockRestore();
+            }
+        });
+
         test('should detect and permanently delete blank New SRFs', async () => {
             const mockDefaultApps = [
                 {

--- a/test/services/application.remindApplicationSubmission.test.js
+++ b/test/services/application.remindApplicationSubmission.test.js
@@ -101,6 +101,61 @@ describe('remindApplicationSubmission', () => {
       expect(calls[1][1]).toBe('finalInactiveReminder'); // short window
     });
 
+    it('passes studyName NA for blank New SRF inactive reminders', async () => {
+      const mockBlankNewApp = {
+        _id: 'app-blank-new',
+        applicantID: 'user-blank',
+        studyAbbreviation: undefined,
+        studyName: undefined,
+        programName: undefined,
+        status: 'New',
+        ORCID: undefined,
+        PI: undefined,
+        programAbbreviation: undefined,
+        programDescription: undefined,
+        history: [],
+        updatedAt: new Date('2023-01-01')
+      };
+
+      mockApplicationDAO.getInactiveApplication
+        .mockResolvedValueOnce([]) // final default
+        .mockResolvedValueOnce([]) // final short
+        .mockResolvedValueOnce([]) // day 7 default (180 - 7)
+        .mockResolvedValueOnce([mockBlankNewApp]) // day 7 short (30 - 7)
+        .mockResolvedValueOnce([]) // day 15 default
+        .mockResolvedValueOnce([]) // day 15 short
+        .mockResolvedValueOnce([]); // day 30 default
+
+      mockApplicationDAO.update.mockResolvedValue({ matchedCount: 1 });
+
+      mockUserService.getUsersByNotifications.mockResolvedValue([]);
+      mockUserService.getUserByID.mockResolvedValue({
+        firstName: 'Blank',
+        lastName: 'User',
+        email: 'blank@example.com',
+        notifications: ['submission_request:expiring']
+      });
+      mockUserService.userCollection.find.mockResolvedValue([]);
+      applicationService.userDAO.findFirst.mockResolvedValue(null);
+
+      await applicationService.remindApplicationSubmission();
+
+      expect(mockNotificationsService.remindApplicationsNotification).toHaveBeenCalledWith(
+        'blank@example.com',
+        [],
+        [],
+        expect.objectContaining({
+          firstName: 'Blank User',
+          studyName: 'NA'
+        }),
+        expect.objectContaining({
+          remainDays: 7,
+          inactiveDays: 23,
+          url: 'http://test.com'
+        })
+      );
+    });
+
     it('should only send short window reminders for blank New SRFs', async () => {
       const mockBlankNewApp = {
         _id: 'app-blank-new',


### PR DESCRIPTION
- ensure that the study section is included in the inactive SRF notifications as NA when it is null